### PR TITLE
pr for publisher-rollback fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "^7.15.6",
     "@reuters-graphics/eslint-config": "^0.0.2",
     "@reuters-graphics/graphics-bin": "^0.0.21",
-    "@reuters-graphics/graphics-kit-publisher": "^0.1.7",
+    "@reuters-graphics/graphics-kit-publisher": "0.1.6",
     "@reuters-graphics/style-ai-templates": ">=0.0.8",
     "@rollup/plugin-dsv": "^2.0.1",
     "@sveltejs/adapter-static": "1.0.0-next.22",


### PR DESCRIPTION
### What's in this pull request

package.json update to call version 0.1.6 instead of 0.1.7 of @reuters-graphics/graphics-kit-publisher.

- [X ] Bug fix
- [ ] New component/feature
- [ ] Documentation update
- [ ] Other

### Description

Change in package.json to load the second-most recent version of graphics-kit-publisher. We had an issue on Friday where `yarn upload` was failing and giving vague hints as to why. Rolling back seemed to do the trick.

### Before submitting, please check that you've

- [ ] Read our [contributing guide](https://github.com/reuters-graphics/bluprint_graphics-kit/blob/master/CONTRIBUTING.md) at some point
- [ ] Formatted you code correctly (i.e., prettier cleaned it up)
- [ ] Documented any new components or features
- [ ] Tagged an editor to review
