### PR TITLE
fix for fetching remote favicon

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,6 +22,16 @@ export default defineConfig({
       },
       favicon:
         'https://graphics.thomsonreuters.com/style-assets/images/logos/favicon/favicon.ico',
+      head: [
+        {
+          tag: 'link',
+          attrs: {
+            rel: 'icon',
+            href: 'https://graphics.thomsonreuters.com/style-assets/images/logos/favicon/favicon.ico',
+            sizes: '32x32',
+          },
+        },
+      ],
       social: {
         github: 'https://github.com/reuters-graphics/bluprint_graphics-kit/',
       },


### PR DESCRIPTION
### What's in this pull request?
Fixes favicon [(reference)](https://starlight.astro.build/reference/configuration/#favicon)

### Before submitting, please check that you've ...

- [x] Read our [contributing guide](https://github.com/reuters-graphics/bluprint_graphics-kit/blob/master/CONTRIBUTING.md)
- [ ] Formatted and linted your code (`pnpm lint` & `pnpm format`)
- [ ] Documented any new components or features
- [ ] Assigned an editor to review this PR
- [ ] If this PR changes code, added a changeset (`npx changeset`)
