### PR TITLE
Fix headline content passed into props to match docs

### DIFF
--- a/locales/en/content.json
+++ b/locales/en/content.json
@@ -30,8 +30,8 @@
       "Jane Doe",
       "John Doe"
     ],
-    "publishedDate": "2024-04-17T17:00:00.000Z",
-    "updatedDate": "",
+    "publishTime": "2024-04-17T17:00:00.000Z",
+    "updateTime": "",
     "blocks": [
       {
         "type": "text",

--- a/src/lib/App.svelte
+++ b/src/lib/App.svelte
@@ -50,8 +50,8 @@
     section={content.section}
     sectionUrl={content.sectionUrl}
     authors={content.authors}
-    publishTime={content.publishedDate}
-    updateTime={content.updatedDate}
+    publishTime={content.publishTime}
+    updateTime={content.updateTime}
   />
 
   <!-- 🔁 Looping through your ArchieML doc blocks... -->


### PR DESCRIPTION
There were some inconsistencies in how `publishTime` was named across component props, rngs.io docs and the components documentation site. Standardised everything to `publishTime`