### PR TITLE
chore: update workflow deps and bump min Node to 22

### DIFF
--- a/.changeset/update-workflow-deps.md
+++ b/.changeset/update-workflow-deps.md
@@ -1,0 +1,14 @@
+---
+'@reuters-graphics/graphics-kit': patch
+---
+
+Update GitHub Actions workflow dependencies and bump the minimum Node version to 22 (testing on 22 and 24).
+
+- `actions/checkout` v4 → v7
+- `pnpm/action-setup` v4 → v6
+- `actions/setup-node` v4 → v6
+- `peter-evans/create-pull-request` v7 → v8
+- `actions/configure-pages` v4 → v6
+- `actions/upload-pages-artifact` v3 → v5
+- `actions/deploy-pages` v4 → v5
+- CI test matrix now runs on Node 22 and 24; `engines.node` bumped to `>=22`.

--- a/.github/publish.yaml
+++ b/.github/publish.yaml
@@ -35,13 +35,13 @@
 #       # This line will notify a Teams channel everytime your project successfully publishes
 #       # GRAPHICS_SERVER_NOTIFY_TEAMS_CHANNEL: # Add a Teams webhook URL here
 #     steps:
-#       - uses: actions/checkout@v4
-#       - uses: pnpm/action-setup@v4
+#       - uses: actions/checkout@v7
+#       - uses: pnpm/action-setup@v6
 #         with:
 #           version: 9
-#       - uses: actions/setup-node@v4
+#       - uses: actions/setup-node@v6
 #         with:
-#           node-version: 20
+#           node-version: 22
 #           cache: pnpm
 #       - run: git config user.name github-actions
 #       - run: git config user.email github-actions@github.com

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -43,13 +43,13 @@ jobs:
         run: pnpm astro build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,21 +20,21 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - id: pnpm
         name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - id: setup
         name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - id: install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     name: SvelteKit builds
     strategy:
       matrix:
-        version: [20, 22]
+        version: [22, 24]
     runs-on: ubuntu-latest
     env:
       TESTING: true
@@ -22,19 +22,19 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - id: pnpm
         name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - id: setup
         name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.version }}
           cache: pnpm

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Update dependencies
@@ -45,7 +45,7 @@ jobs:
           EOF
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update dependencies'

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "vitest": "^3.0.7"
   },
   "engines": {
-    "node": ">=20.18"
+    "node": ">=22"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

Updates the dependencies pinned in our GitHub Actions workflows and raises the minimum supported Node version.

### Action version bumps
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `pnpm/action-setup` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `peter-evans/create-pull-request` | v7 | v8 |
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`changesets/action` stays at `@v1` (already the latest major); `JasonEtco/create-an-issue@v2` left as-is (out of scope, still current major).

### Node version
- `test.yaml` matrix: `[20, 22]` → `[22, 24]` (min 22, also testing 24)
- `docs.yaml`, `release.yaml`, `update-dependencies.yaml`: `node-version` 20 → 22
- `package.json` `engines.node`: `>=20.18` → `>=22`
- `publish.yaml` (commented publish template) bumped to match

Applied across all four active workflows plus the commented `publish.yaml` template that scaffolded projects rely on. Includes a changeset (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)