### PR TITLE
feat: set up gfx working branch for scaffolded projects

### DIFF
--- a/.changeset/gfx-branch-workflow.md
+++ b/.changeset/gfx-branch-workflow.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': minor
+---
+
+Scaffolding now sets up a `gfx` working branch for new graphics projects. `main` is pushed as the protected default branch, then a `gfx` branch is created, pushed, and checked out — a temporary workaround for org default-branch protection that blocks our shared-branch deadline workflow. A new `.claude/context/git-workflow.md` doc ships with scaffolded projects explaining the `gfx` workflow and how to migrate back once the restriction is lifted.

--- a/.claude/context/git-workflow.md
+++ b/.claude/context/git-workflow.md
@@ -1,0 +1,27 @@
+# Git workflow
+
+## ⚠️ Push and pull to `gfx`, not `main`
+
+**This project's working branch is `gfx`.** Do all day-to-day work on `gfx` and push and pull there. Scaffolding leaves you checked out on `gfx` already.
+
+**Do not push to `main`.** It is the protected default branch and direct pushes are blocked.
+
+## Why
+
+Our company applies branch-protection rules to the default branch (`main`) on every repo: after the initial push you can't push to it without opening a formal PR, and the company's PR security checks take too long to clear on deadline.
+
+Our team works differently — several developers share one branch at once, each owning a different graphic or part of the app, and we publish straight from our own machines. The publishing tools upload the files on your machine regardless of which branch you're on, so the branch name has no bearing on what ships. To keep moving on deadline we treat **`gfx`** as the de-facto working branch and leave `main` as the untouched, protected default.
+
+## How it's set up
+
+- `main` — pushed once at scaffold time, then left alone. It's the protected default branch on GitHub.
+- `gfx` — the shared working branch. Created and pushed at scaffold time; this is where everyone commits.
+- Multiple developers commit to `gfx` at the same time, so **pull often** (`git pull`) to stay in sync and avoid conflicts.
+
+## When the restriction is lifted
+
+This is a **temporary workaround** while we negotiate to have the default-branch restriction removed from our team's repos. Once it's lifted, migrate this project back to a normal `main` workflow:
+
+1. Merge `gfx` into `main`: `git checkout main && git merge gfx`
+2. Push `main` and resume working on it: `git push origin main`
+3. Delete the working branch: `git branch -d gfx && git push origin --delete gfx`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This repo also contains a **docs site**, an Astro Starlight site in `/docs/` wit
 
 Always keep template work and docs work clearly separate.
 
+## The `gfx` branch workaround (scaffolded projects only)
+
+`bluprint.config.ts` sets up a `gfx` working branch for each scaffolded project, and `.claude/context/git-workflow.md` documents it. **That workflow governs scaffolded graphics projects only — it does NOT apply to this template repo.** This repo uses normal GitHub Flow on `main` via PRs (see `CONTRIBUTING.md`); ignore `.claude/context/git-workflow.md` when working here (it exists in this repo only so it ships into scaffolded projects).
+
+It's a **temporary** measure while we negotiate to remove the org's default-branch restriction on our repos. To remove it once that lands, delete the `gfx workflow` block of `execute` actions in `bluprint.config.ts` and the `.claude/context/git-workflow.md` doc (and the Git workflow section in `PROJECT_CLAUDE.md`).
+
 ## Tech stack
 
 - **SvelteKit** with **Svelte 5** — always use Svelte 5 runes syntax (`$state`, `$derived`, `$effect`, etc.)

--- a/PROJECT_CLAUDE.md
+++ b/PROJECT_CLAUDE.md
@@ -32,6 +32,10 @@ Most graphics projects publish a single page for reuters.com, an embeddable vers
 
 Other projects may have additional pages for reuters.com (any additional page in the `pages/` directory) or addition embeds of individual graphics (pages in the `pages/embeds/` directory).
 
+## Git workflow
+
+This project's working branch is **`gfx`**, not `main`. Push and pull to `gfx`. For the full explanation and how to migrate back once the restriction is lifted, read [`.claude/context/git-workflow.md`](.claude/context/git-workflow.md).
+
 ## External services
 
 - **rngs.io** is the Reuters Graphics CMS for writing page text and other structured data we want to edit in collaboration with others in our newsroom. We export that content to JSON files in the `locales/` directory. Those JSON files are synced and connections between the project and editable documents in rngs.io using the `rngs-io` CLI (see `stories:` prefixed scripts in `package.json`), provided by the `@reuters-graphics/rngs-io-client` library. Configuration for rngs.io connections is in `rngs-io.json`. For adding translations, read [`.claude/context/translations.md`](.claude/context/translations.md).

--- a/bluprint.config.ts
+++ b/bluprint.config.ts
@@ -126,8 +126,18 @@ export default defineConfig<Context>({
 
     execute('pnpm startup:create-repo'),
 
+    // --- gfx workflow (temporary workaround for org default-branch protection) ---
+    // See `.claude/context/git-workflow.md` in scaffolded projects for the why.
+    // Normalize the local default branch to `main` (some devs' git defaults to `master`).
+    execute(['git', 'branch', '-M', 'main'], { silent: true }),
+    // Push `main` first so GitHub adopts it as the (protected) default branch.
+    execute('git push -u origin main'),
+    // Create + push the shared `gfx` working branch and leave the dev checked out on it.
+    execute(['git', 'checkout', '-b', 'gfx'], { silent: true }),
+    execute('git push -u origin gfx'),
+
     log(
-      '\n\n🏁 Finished creating your project, {cyan {{ projectName }}}!\n\nRun {green pnpm start} to begin developing.\n'
+      "\n\n🏁 Finished creating your project, {cyan {{ projectName }}}!\n\nYou're on the {cyan gfx} branch — push and pull to {cyan gfx}, not main.\n\nRun {green pnpm start} to begin developing.\n"
     ),
   ],
 });


### PR DESCRIPTION
## Summary

Automates our team's default-branch-protection workaround directly in the scaffolding flow, so developers don't have to remember the manual steps on every new project.

**The problem:** the company applies branch protection to the default branch (`main`) on all repos — direct pushes are blocked after the initial push, and PR security checks are too slow to clear on deadline. Our team shares a single working branch across developers and publishes from local machines (branch name doesn't affect what ships), so we treat a `gfx` branch as the de-facto working branch and leave `main` as the protected default.

## What this does (scaffolded projects only)

In `bluprint.config.ts`, after `startup:create-repo` (which creates an empty repo and adds the `origin` remote but never pushes):

- `git branch -M main` — normalizes the local branch to `main` (some devs' git defaults to `master`)
- push `main` first — GitHub adopts it as the (protected) default branch
- `git checkout -b gfx` + push — creates the shared working branch and leaves the developer checked out on it

The closing scaffold message now tells the developer they're on `gfx`.

## Docs

- **`.claude/context/git-workflow.md`** (new) — ships into scaffolded projects; leads with "push/pull to `gfx`", explains why, and documents how to migrate back to `main` once the restriction is lifted.
- **`PROJECT_CLAUDE.md`** — new "Git workflow" section linking the doc.
- **`CLAUDE.md`** (root, template-only — stripped on scaffold) — clarifies the `gfx` workflow governs scaffolded projects only, NOT this template repo (which keeps normal GitHub Flow on `main` via `CONTRIBUTING.md`), and notes where to remove the workaround later.

## Notes

- This is a **temporary** measure while we negotiate to remove the org restriction — built to be easy to rip out (the `gfx` block in `bluprint.config.ts` + the doc).
- If a developer picks "Don't create a repo" during scaffolding, there's no `origin`; the pushes log an error and the scaffold continues (no repo means no protection problem). `failOnError` is intentionally left off for this reason.

## Verification

- `prettier --check` passes on all touched files.
- Dry-ran the exact git sequence in a throwaway dir with `init.defaultBranch=master` against a local bare remote: confirmed the rename to `main`, `main` set as the remote's default branch, `gfx` created/pushed/tracked, and HEAD ending on `gfx`.
- Confirmed scope invariants: root `CLAUDE.md` is stripped on scaffold (note won't leak); `git-workflow.md` is in no remove/ignore list (it ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)