### PR TITLE
chore: move build-script allowlist to pnpm-workspace.yaml for pnpm 10/11

### DIFF
--- a/.changeset/pnpm-v11-build-config.md
+++ b/.changeset/pnpm-v11-build-config.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': minor
+---
+
+Move the build-script allowlist for dependencies with postinstall steps (sharp, esbuild, lefthook, etc.) from the `pnpm` field in `package.json` into a new `pnpm-workspace.yaml`. pnpm 11 no longer reads the `package.json#pnpm` field and renamed `onlyBuiltDependencies` to `allowBuilds`, so the file lists both keys — `onlyBuiltDependencies` (read by pnpm 10) and `allowBuilds` (read by pnpm 11) — to work on both. Requires pnpm >= 10; CI workflows now install pnpm 10.

--- a/.github/publish.yaml
+++ b/.github/publish.yaml
@@ -38,7 +38,7 @@
 #       - uses: actions/checkout@v7
 #       - uses: pnpm/action-setup@v6
 #         with:
-#           version: 9
+#           version: 10
 #       - uses: actions/setup-node@v6
 #         with:
 #           node-version: 22

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - id: setup
         name: Setup Node.js

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - id: setup
         name: Setup Node.js

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -90,19 +90,6 @@
   "engines": {
     "node": ">=22"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@evilmartians/lefthook",
-      "@fortawesome/fontawesome-common-types",
-      "@fortawesome/free-regular-svg-icons",
-      "@fortawesome/free-solid-svg-icons",
-      "@parcel/watcher",
-      "@sveltejs/kit",
-      "esbuild",
-      "sharp",
-      "svelte-preprocess"
-    ]
-  },
   "dependencies": {
     "@reuters-graphics/graphics-components": "^3.10.1",
     "language-tags": "^1.0.9"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,31 @@
+# Dependencies allowed to run postinstall/build scripts.
+#
+# pnpm 11 no longer reads the `pnpm` field in package.json and renamed
+# `onlyBuiltDependencies` to the `allowBuilds` map. We list both keys so the
+# config works on pnpm 10 (reads `onlyBuiltDependencies`, ignores `allowBuilds`)
+# and pnpm 11 (reads `allowBuilds`, ignores `onlyBuiltDependencies`). Keep the
+# two lists in sync. Requires pnpm >= 10 — pnpm 9 does not read this file.
+
+# Read by pnpm 10
+onlyBuiltDependencies:
+  - '@evilmartians/lefthook'
+  - '@fortawesome/fontawesome-common-types'
+  - '@fortawesome/free-regular-svg-icons'
+  - '@fortawesome/free-solid-svg-icons'
+  - '@parcel/watcher'
+  - '@sveltejs/kit'
+  - esbuild
+  - sharp
+  - svelte-preprocess
+
+# Read by pnpm 11
+allowBuilds:
+  '@evilmartians/lefthook': true
+  '@fortawesome/fontawesome-common-types': true
+  '@fortawesome/free-regular-svg-icons': true
+  '@fortawesome/free-solid-svg-icons': true
+  '@parcel/watcher': true
+  '@sveltejs/kit': true
+  esbuild: true
+  sharp: true
+  svelte-preprocess: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,10 @@ allowBuilds:
   esbuild: true
   sharp: true
   svelte-preprocess: true
+
+# pnpm 11 enforces a minimum release age (default 1440 min / 24h) before a
+# newly published version can be installed. Exempt our own scoped packages so
+# freshly released @reuters-graphics/* versions install immediately; all other
+# dependencies keep the default waiting period. (Ignored by pnpm 10.)
+minimumReleaseAgeExclude:
+  - '@reuters-graphics/*'


### PR DESCRIPTION
## Summary

Closes #314.

Makes the postinstall/build-script allowlist work on **both pnpm 10 and pnpm 11**.

pnpm 11 introduced two breaking changes that quietly disable our current setup:
1. It **no longer reads the `pnpm` field in `package.json`** — settings must live in `pnpm-workspace.yaml`.
2. It **removed `onlyBuiltDependencies`**, replacing it with an `allowBuilds` map.

With the old config, a `pnpm 11` install prints `WARN … "pnpm.onlyBuiltDependencies" … ignored` and then fails with `ERR_PNPM_IGNORED_BUILDS`.

## Changes

- **New `pnpm-workspace.yaml`** holding the allowlist under *both* keys:
  - `onlyBuiltDependencies` — read by pnpm 10
  - `allowBuilds` — read by pnpm 11

  Each version reads the key it knows and silently ignores the other. (Keep the two lists in sync.)
- **Removed** the `pnpm.onlyBuiltDependencies` block from `package.json`.
- **Bumped CI pnpm 9 → 10** in all workflows (`test`, `release`, `docs`, `update-dependencies`) and the commented `publish.yaml` template. Settings in `pnpm-workspace.yaml` didn't exist before pnpm 10.6, so pnpm 9 would silently skip these build scripts.
- **Exempted `@reuters-graphics/*` from pnpm 11's minimum release age.** pnpm 11 defaults `minimumReleaseAge` to 1440 min (24h), delaying installs of freshly published versions. Added `minimumReleaseAgeExclude: ['@reuters-graphics/*']` so our own scoped packages install immediately; all other dependencies keep the default waiting period. (Ignored by pnpm 10.)

The new `pnpm-workspace.yaml` ships into scaffolded projects (it's not in `bluprint.config.ts`'s remove/ignore lists), which is intended — scaffolded projects need the same allowlist.

## Verification

Tested empirically across **pnpm 9.15.9 / 10.11.1 / 11.10.0** with a dependency whose `postinstall` writes a marker file (and cross-checked with real packages):

| Config | pnpm 9 | pnpm 10 | pnpm 11 |
|---|---|---|---|
| `package.json → pnpm.onlyBuiltDependencies` (old) | ✅ | ✅ | ❌ ignored, install errors |
| `pnpm-workspace.yaml → both keys` (new) | ❌ not read | ✅ | ✅ |

- Neither pnpm 10 nor pnpm 11 complained about the "foreign" key it doesn't recognize.
- Ran `pnpm@10` install on this repo: clean, no ignored-builds warning, **lockfile unchanged**.
- Ran `pnpm@11` install on this repo (frozen lockfile): `rc=0`, no ignored-builds error, and it actually executed an allowlisted build (`svelte-preprocess postinstall: Done`) — confirming `allowBuilds` is honored.
- `pnpm@11 config get minimumReleaseAgeExclude` returns `["@reuters-graphics/*"]`, confirming the exclusion is read; pnpm 10 install stays clean (ignores the setting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
