### PR TITLE
feat: expose __BASE_URL__ global for SEO baseUrl

### DIFF
--- a/.changeset/seo-base-url.md
+++ b/.changeset/seo-base-url.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': patch
+---
+
+Expose a fully specified `__BASE_URL__` global (injected at build time via Vite `define` from `getBasePath(mode, { trailingSlash: true, rootRelative: false })`) and pass it to the `SEO` component's `baseUrl` prop, so prerendered canonical/OG URLs use the correct site origin instead of the CDN asset path.

--- a/bin/mods/mods/make-ai-embed/templates/pages/embeds/[locale]/[slug]/+page.svelte
+++ b/bin/mods/mods/make-ai-embed/templates/pages/embeds/[locale]/[slug]/+page.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle=""
   seoDescription=""

--- a/bin/mods/mods/make-blog/templates/pages/+page.svelte
+++ b/bin/mods/mods/make-blog/templates/pages/+page.svelte
@@ -42,7 +42,7 @@
 {/if}
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle={content.seoTitle}
   seoDescription={content.seoDescription}

--- a/bin/mods/mods/make-blog/templates/pages/[date]/[slug]/+page.svelte
+++ b/bin/mods/mods/make-blog/templates/pages/[date]/[slug]/+page.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle={post?.slugTitle}
   seoDescription={post?.seoDescription}

--- a/bin/mods/mods/project-type/templates/embed-only/pages/+page.svelte
+++ b/bin/mods/mods/project-type/templates/embed-only/pages/+page.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle=""
   seoDescription=""

--- a/bin/mods/mods/project-type/templates/pages-plus/pages/+page.svelte
+++ b/bin/mods/mods/project-type/templates/pages-plus/pages/+page.svelte
@@ -30,7 +30,7 @@
 {/if}
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle={content.seoTitle}
   seoDescription={content.seoDescription}

--- a/bin/mods/mods/project-type/templates/pages-plus/pages/embeds/en/page/+page.svelte
+++ b/bin/mods/mods/project-type/templates/pages-plus/pages/embeds/en/page/+page.svelte
@@ -21,7 +21,7 @@
 </svelte:head>
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle={content.seoTitle}
   seoDescription={content.seoDescription}

--- a/docs/content/docs/Developers/11-adding-pages.mdx
+++ b/docs/content/docs/Developers/11-adding-pages.mdx
@@ -51,7 +51,7 @@ import { story as content } from '$locales/en/anotherPage.json';
 </script>
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle={content.seoTitle}
   seoDescription={content.seoDescription}
@@ -64,6 +64,8 @@ import { story as content } from '$locales/en/anotherPage.json';
   authors={pkg?.reuters?.graphic?.authors}
 />
 ```
+
+`__BASE_URL__` is the fully specified base URL for your project. It's injected at build time in `vite.config.ts` and available as a global anywhere in your app — no import needed. The `SEO` component uses it to build canonical and share URLs with the correct origin.
 
 ## Adding embeds
 
@@ -94,7 +96,7 @@ Embed pages **must** have a canonical link element and should have a [`robots` m
 </script>
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   shareImgPath={asset('/another-page-share.jpg')}
 />

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,12 @@ export default [
   },
   ...svelte,
   {
+    // Build-time constant injected by Vite `define` (see vite.config.ts).
+    languageOptions: {
+      globals: {
+        __BASE_URL__: 'readonly',
+      },
+    },
     rules: {
       'svelte3/unused-export-let': 'off',
     },

--- a/pages/+page.svelte
+++ b/pages/+page.svelte
@@ -30,7 +30,7 @@
 {/if}
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle={content.seoTitle}
   seoDescription={content.seoDescription}

--- a/pages/embeds/en/page/+page.svelte
+++ b/pages/embeds/en/page/+page.svelte
@@ -21,7 +21,7 @@
 </svelte:head>
 
 <SEO
-  baseUrl={asset('/')}
+  baseUrl={__BASE_URL__}
   pageUrl={page.url}
   seoTitle={content.seoTitle}
   seoDescription={content.seoDescription}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,11 @@
+/**
+ * Fully specified base URL for the page, injected at build time by Vite
+ * (see `vite.config.ts`) from
+ * `getBasePath(mode, { trailingSlash: true, rootRelative: false })`.
+ * Pass to the SEO component's `baseUrl` prop.
+ */
+declare const __BASE_URL__: string;
+
 declare module '@svelte-kit-pages' {
   const embeds: string[];
   export default embeds;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,27 @@
 import { purgeStyles } from '@reuters-graphics/vite-plugin-purge-styles';
 import svelteKitPagesPlugin from './bin/svelte-kit/plugins/svelte-kit-pages/';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { getBasePath } from '@reuters-graphics/graphics-kit-publisher';
 import { defineConfig } from 'vitest/config';
 
+// Keep in sync with the `mode` computation in svelte.config.js
+const mode =
+  process.env.TESTING ? 'test'
+  : process.env.PREVIEW ? 'preview'
+  : process.env.NODE_ENV === 'production' ? 'prod'
+  : 'dev';
+
+// Fully specified base URL for the page, exposed to the app as the global
+// __BASE_URL__ (e.g. for the SEO component's baseUrl prop).
+const baseUrl = getBasePath(mode, {
+  trailingSlash: true,
+  rootRelative: false,
+});
+
 export default defineConfig({
+  define: {
+    __BASE_URL__: JSON.stringify(baseUrl),
+  },
   build: {
     target: 'es2015',
     sourcemap: true,


### PR DESCRIPTION
## What

Exposes a fully specified `__BASE_URL__` global to the app and uses it for the `SEO` component's `baseUrl` prop, replacing `asset('/')`.

- **vite.config.ts** injects the value at build time via Vite `define`, sourced from `getBasePath(mode, { trailingSlash: true, rootRelative: false })`. Available anywhere as the global `__BASE_URL__` — no import needed.
- **src/global.d.ts** types the global; **eslint.config.js** declares it as a known ESLint global (otherwise `no-undef` fires in Svelte files).
- Both base template pages, all mod templates that render `SEO` (project-type pages-plus/embed-only, make-ai-embed, make-blog), and the "Adding pages" docs examples now pass `__BASE_URL__`.

## Why

`SEO` only reads `.origin` off `baseUrl` and combines it with `page.url.pathname`. The old `asset('/')` resolves against the **CDN** path (`paths.assets`) — its origin happened to match, but it's semantically the wrong input. `__BASE_URL__` is the page's own fully specified base.

Injecting at **build time** (rather than reading `page.url.origin` at runtime) matters because this is a prerendered static site — at prerender `page.url.origin` is SvelteKit's placeholder, so runtime-derived origins would bake wrong canonical/OG tags into the HTML.

Named `__BASE_URL__` (Vite's convention for defined constants) rather than `BASE_URL`, which is a reserved Vite built-in. Since we own the `define`, there's no need to hang it off the `import.meta.env` namespace.

## Testing

- `pnpm check` — 0 errors
- `pnpm lint` — clean (global declared in eslint.config.js)
- `pnpm build` — succeeds; compiled JS contains no live `__BASE_URL__` token (the `define` replaced it), prerendered canonical renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)