### PR TITLE
test: relocate TWD to system temp dir and verify __BASE_URL__ across build modes

### DIFF
--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -3,31 +3,77 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import * as cheerio from 'cheerio';
+import { globSync } from 'glob';
+import { getBasePath } from '@reuters-graphics/graphics-kit-publisher';
 import { TestWorkingDirectory } from './utils/twd';
 
 const twd = new TestWorkingDirectory();
 
-const DIST = path.join(twd.TWD, 'dist/');
+// Mock the base URLs the publisher reads from package.json so preview and prod
+// builds resolve to known values. Different hosts so that per-mode origin
+// extraction is genuinely exercised. (test mode ignores package.json and uses
+// the publisher's fixed fake URL.)
+const MOCK_PROD_URL = 'https://www.reuters.com/testing/prod/';
+const MOCK_PREVIEW_URL = 'https://graphics.thomsonreuters.com/testing/preview/';
 
-process.env.TESTING = 'true';
+// The fully specified base URL injected into each build as `__BASE_URL__`
+// (see vite.config.ts), keyed by mode. `test` derives from the publisher's
+// constant; `preview`/`prod` come from the mocked package.json values above.
+const EXPECTED_BASE_URL = {
+  test: getBasePath('test', { trailingSlash: true, rootRelative: false }),
+  preview: MOCK_PREVIEW_URL,
+  prod: MOCK_PROD_URL,
+} as const;
+
+type Mode = keyof typeof EXPECTED_BASE_URL;
+const MODES = Object.keys(EXPECTED_BASE_URL) as Mode[];
+
+const distDir = (mode: Mode) => path.join(twd.TWD, `dist-${mode}`);
+
+// The test-mode output backs the general build assertions below.
+const DIST = distDir('test');
+
+/**
+ * Build the app in a given mode as a fresh `vite build` subprocess (which
+ * re-reads the mocked package.json from the TWD), then stash the output in a
+ * mode-specific directory so each mode's assertions are order-independent.
+ */
+const buildMode = (mode: Mode) => {
+  const env: NodeJS.ProcessEnv = { ...process.env, TESTING: '', PREVIEW: '' };
+  if (mode === 'test') env.TESTING = 'true';
+  else if (mode === 'preview') env.PREVIEW = 'true';
+  else env.NODE_ENV = 'production';
+
+  execSync('vite build', { cwd: twd.TWD, env, stdio: 'ignore' });
+
+  const out = distDir(mode);
+  fs.rmSync(out, { recursive: true, force: true });
+  fs.cpSync(path.join(twd.TWD, 'dist'), out, { recursive: true });
+};
 
 describe('GraphicsKit build', () => {
   beforeAll(async () => {
     await twd.setup();
-  });
+
+    // Mock the base URL sources getBasePath reads from package.json.
+    const pkgPath = path.join(twd.TWD, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    pkg.homepage = MOCK_PROD_URL;
+    pkg.reuters = { ...(pkg.reuters ?? {}), preview: MOCK_PREVIEW_URL };
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+    for (const mode of MODES) buildMode(mode);
+  }, 180_000);
 
   afterAll(async () => {
     await twd.cleanup();
   });
 
-  it('should build the app without error', async () => {
-    try {
-      execSync('vite build');
-    } catch {
-      expect(false).toBe(true);
+  it('should build every mode without error', () => {
+    for (const mode of MODES) {
+      expect(fs.existsSync(path.join(distDir(mode), 'index.html'))).toBe(true);
     }
-    expect(true).toBe(true);
-  }, 30_000);
+  });
 
   it('should build the homepage', () => {
     expect(fs.existsSync(path.join(DIST, 'index.html'))).toBe(true);
@@ -90,4 +136,46 @@ describe('GraphicsKit build', () => {
       fs.existsSync(path.join(DIST, 'cdn/images/reuters-graphics.jpg'))
     ).toBe(true);
   });
-}, 90_000);
+
+  describe('__BASE_URL__ injection', () => {
+    describe.each(MODES)('%s mode', (mode) => {
+      const base = EXPECTED_BASE_URL[mode];
+      const origin = new URL(base).origin;
+      const dist = distDir(mode);
+
+      it('sets the base URL origin in homepage SEO tags', () => {
+        const $ = cheerio.load(
+          fs.readFileSync(path.join(dist, 'index.html'), 'utf-8')
+        );
+        expect($('link[rel=canonical]').attr('href')).toBe(base);
+        expect($('meta[property=og:url]').attr('content')).toBe(base);
+        expect($('meta[name=twitter:domain]').attr('content')).toBe(origin);
+      });
+
+      it('sets the base URL origin in embed page SEO tags', () => {
+        const embedUrl = new URL('embeds/en/page/', base).href;
+        const $ = cheerio.load(
+          fs.readFileSync(path.join(dist, 'embeds/en/page/index.html'), 'utf-8')
+        );
+        expect($('link[rel=canonical]').attr('href')).toBe(embedUrl);
+        expect($('meta[property=og:url]').attr('content')).toBe(embedUrl);
+        expect($('meta[name=twitter:domain]').attr('content')).toBe(origin);
+      });
+    });
+
+    it('should replace the __BASE_URL__ token at build time', () => {
+      // The Vite `define` should inline the value, leaving no raw token in the
+      // built output. Sourcemaps legitimately retain the original source, so
+      // only check emitted JS and HTML.
+      const built = globSync(['**/*.js', '**/*.html'], {
+        cwd: DIST,
+        nodir: true,
+        absolute: true,
+      });
+      expect(built.length).toBeGreaterThan(0);
+      for (const file of built) {
+        expect(fs.readFileSync(file, 'utf-8')).not.toContain('__BASE_URL__');
+      }
+    });
+  });
+}, 180_000);

--- a/test/utils/twd.ts
+++ b/test/utils/twd.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
 import ignore from 'ignore';
 import fsPromises from 'fs/promises';
@@ -7,7 +8,10 @@ import { execSync } from 'child_process';
 
 export class TestWorkingDirectory {
   CWD = process.cwd();
-  TWD = path.join(process.cwd(), 'test', '.temp');
+  // A unique directory in the system temp dir (rather than inside the repo's
+  // own test/ folder). `node_modules` is symlinked in by absolute path, so the
+  // location doesn't matter, and os.tmpdir() is writable in GitHub Actions.
+  TWD = fs.mkdtempSync(path.join(os.tmpdir(), 'bluprint-graphics-kit-'));
 
   private async createSymlink(srcPath: string) {
     const symlinkSource = path.join(this.CWD, srcPath);


### PR DESCRIPTION
## What

Two test-only changes, no product code touched:

1. **`TestWorkingDirectory` now builds in the system temp dir.** Replaces the `test/.temp` folder inside the repo with `fs.mkdtempSync(os.tmpdir(), …)`. `node_modules` is symlinked in by absolute path so the location is irrelevant, `os.tmpdir()` is writable on GitHub Actions, and each instance gets a unique dir.

2. **Build test verifies `__BASE_URL__` metadata across all three modes** (`test`, `preview`, `prod`). A single TWD mocks `homepage` and `reuters.preview` in its `package.json`, then builds each mode as a fresh `vite build` subprocess (which re-reads that package.json) into its own `dist-<mode>` directory.

## Why

`__BASE_URL__` (added in a prior PR) is injected at build time and feeds the `SEO` component's `baseUrl`. These tests lock down that:
- canonical / `og:url` / `twitter:domain` reflect the correct base URL and origin for each mode, on both the homepage and embed page;
- the Vite `define` actually inlines the value (no raw `__BASE_URL__` token in emitted JS/HTML).

Using distinct hosts for the preview (`graphics.thomsonreuters.com`) and prod (`www.reuters.com`) mocks means the package.json mocking is genuinely exercised per mode.

## Testing

- `npx vitest run test/build.test.ts` → 15 passed (~32s)
- Full suite green; ESLint clean.

No changeset — test-only, no effect on the published template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)