### PR TITLE
feat: populate SEO component's new metadata props

### DIFF
--- a/.changeset/seo-metadata-props.md
+++ b/.changeset/seo-metadata-props.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': minor
+---
+
+Populate the SEO component's new metadata props across the page templates and the blog mod: `articleSection`, `keywords`, `locale`, and share image dimensions (`shareImgWidth`/`shareImgHeight`). Adds the backing `keywords`/`locale`/`section` fields to the content JSON, extends the blog mod's `PostStory`/`MainPageShell` types accordingly, and bumps `@reuters-graphics/graphics-components` to 4.2.0.

--- a/bin/mods/mods/make-blog/templates/_mocks.d.ts
+++ b/bin/mods/mods/make-blog/templates/_mocks.d.ts
@@ -21,6 +21,7 @@ declare module '$lib/post' {
     blocks: Block[];
     seoDescription?: string;
     shareImgPath?: string;
+    keywords?: string;
     [key: string]: unknown;
   }
 
@@ -32,6 +33,8 @@ declare module '$lib/post' {
     shareImgPath: string;
     shareImgAlt: string;
     section: string;
+    keywords?: string;
+    locale?: string;
     mainHeadline: string;
     endNotes: { title: string; text: string }[];
   }

--- a/bin/mods/mods/make-blog/templates/locales/en/content.json
+++ b/bin/mods/mods/make-blog/templates/locales/en/content.json
@@ -10,6 +10,8 @@
     "shareDescription": "Page description for social media",
     "shareImgPath": "images/share-card.png",
     "shareImgAlt": "A map of the border region between Israel and Lebanon. The map includes annotations for the positions of tank fire and a Reuters team.",
+    "keywords": "Graphics, News, Reuters News",
+    "locale": "en_GB",
     "section": "Topic Kicker",
     "mainHeadline": "Reuters Graphics Blog",
     "endNotes": [

--- a/bin/mods/mods/make-blog/templates/locales/en/post-1.json
+++ b/bin/mods/mods/make-blog/templates/locales/en/post-1.json
@@ -12,6 +12,7 @@
     "shareDescription": "Page description for social media",
     "shareImgPath": "images/share-card.png",
     "shareImgAlt": "Alt text for share image",
+    "keywords": "Graphics, News, Reuters News",
     "authors": ["Jane Doe", "John Doe"],
     "publishedDate": "2026-04-09T19:00:00.000Z",
     "updatedDate": "",

--- a/bin/mods/mods/make-blog/templates/pages/+page.svelte
+++ b/bin/mods/mods/make-blog/templates/pages/+page.svelte
@@ -50,9 +50,17 @@
   shareDescription={content.shareDescription}
   shareImgPath={asset(`/${content.shareImgPath}`)}
   shareImgAlt={content.shareImgAlt}
+  shareImgWidth={1200}
+  shareImgHeight={628}
   publishTime={pkg?.reuters?.graphic?.published}
   updateTime={pkg?.reuters?.graphic?.updated}
   authors={pkg?.reuters?.graphic?.authors}
+  articleSection={content.section}
+  keywords={content.keywords
+    ?.split(',')
+    .map((k) => k.trim())
+    .filter(Boolean)}
+  locale={content.locale}
 />
 
 <Headline

--- a/bin/mods/mods/make-blog/templates/pages/[date]/[slug]/+page.svelte
+++ b/bin/mods/mods/make-blog/templates/pages/[date]/[slug]/+page.svelte
@@ -41,9 +41,17 @@
   shareDescription=""
   shareImgPath={asset(`/${post?.shareImgPath || content.shareImgPath}`)}
   shareImgAlt={content.shareImgAlt}
+  shareImgWidth={1200}
+  shareImgHeight={628}
   publishTime={post?.publishedDate}
   updateTime={post?.updatedDate}
   {authors}
+  articleSection={content.section}
+  keywords={post.keywords
+    ?.split(',')
+    .map((k) => k.trim())
+    .filter(Boolean)}
+  locale={content.locale}
 />
 
 {#if post}

--- a/bin/mods/mods/make-blog/templates/src/lib/post.ts
+++ b/bin/mods/mods/make-blog/templates/src/lib/post.ts
@@ -34,6 +34,8 @@ export interface PostStory {
   shareDescription?: string;
   shareImgPath?: string;
   shareImgAlt?: string;
+  /** Comma-separated keywords/tags, split into an array for the SEO component. */
+  keywords?: string;
   authors: string[];
   publishedDate: string;
   updatedDate: string;
@@ -52,6 +54,10 @@ export interface MainPageShell {
   shareImgPath: string;
   shareImgAlt: string;
   section: string;
+  /** Comma-separated keywords/tags, split into an array for the SEO component. */
+  keywords?: string;
+  /** Open Graph locale, e.g. `en_GB`. */
+  locale?: string;
   mainHeadline: string;
   endNotes: { title: string; text: string }[];
 }

--- a/bin/mods/mods/project-type/templates/pages-plus/pages/+page.svelte
+++ b/bin/mods/mods/project-type/templates/pages-plus/pages/+page.svelte
@@ -38,9 +38,17 @@
   shareDescription={content.shareDescription}
   shareImgPath={asset(`/${content.shareImgPath}`)}
   shareImgAlt={content.shareImgAlt}
+  shareImgWidth={1200}
+  shareImgHeight={628}
   publishTime={pkg?.reuters?.graphic?.published}
   updateTime={pkg?.reuters?.graphic?.updated}
   authors={pkg?.reuters?.graphic?.authors}
+  articleSection={content.section}
+  keywords={content.keywords
+    ?.split(',')
+    .map((k) => k.trim())
+    .filter(Boolean)}
+  locale={content.locale}
 />
 
 <Theme base="light">

--- a/locales/en/content.json
+++ b/locales/en/content.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
     "id": "cltmvzj5m0000lc089jz22aet",
-    "name": "graphics-kit-page",
+    "name": "Graphic: Page",
     "storyboard": {
       "id": "cltmvxt5q0000l908irus4rdd",
       "name": "🔒 TEMPLATES"
     },
-    "lastSynced": "2025-03-26T17:16:03.466Z",
+    "lastSynced": "2026-07-10T20:27:43.097Z",
     "liveEditing": {
       "preview": {
         "aml": "https://graphics.thomsonreuters.com/apps/graphics-tools/prod/stories/cltmvzj5m0000lc089jz22aet/preview/story.aml",
@@ -23,16 +23,18 @@
     "shareDescription": "Page description for social media",
     "shareImgPath": "images/reuters-graphics.jpg",
     "shareImgAlt": "Alt text for share image.",
-    "hed": "A Reuters Graphics page",
     "section": "Graphics",
+    "keywords": "Graphics, News",
+    "locale": "en_GB",
+    "hed": "A Reuters Graphics page",
     "sectionUrl": "https://www.reuters.com/graphics/",
     "authors": ["Jane Doe", "John Doe"],
-    "publishTime": "2024-04-17T17:00:00.000Z",
+    "publishTime": "2025-10-20T17:00:00.000Z",
     "updateTime": "",
     "blocks": [
       {
         "type": "text",
-        "text": "Pig short ribs jerky, meatloaf turducken ribeye strip steak bacon pastrami tail pancetta chicken. Turkey landjaeger <a href=\"https://www.reuters.com/graphics/\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">kevin turducken kielbasa</a> pork loin, filet mignon leberkas meatball cow tenderloin. T-bone meatloaf kielbasa pancetta filet mignon doner. \r\n\r\nPig short ribs jerky, meatloaf <em>turducken ribeye strip steak</em> bacon pastrami tail pancetta chicken. Shankle pork loin burgdoggen, prosciutto beef ribs turducken ball tip.\r\n\r\nBoudin alcatra kevin, jerky swine <strong>brisket pastrami</strong> tail pork chop drumstick tongue."
+        "text": "Pig short ribs jerky, meatloaf turducken ribeye strip steak bacon pastrami tail pancetta chicken. Turkey landjaeger <a href=\"https://www.reuters.com/graphics/\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">kevin turducken kielbasa</a> pork loin, filet mignon leberkas meatball cow tenderloin. T-bone meatloaf kielbasa pancetta filet mignon doner.\r\n\r\nPig short ribs jerky, meatloaf <em>turducken ribeye strip steak</em> bacon pastrami tail pancetta chicken. Shankle pork loin burgdoggen, prosciutto beef ribs turducken ball tip.\r\n\r\nBoudin alcatra kevin, jerky swine <strong>brisket pastrami</strong> tail pork chop drumstick tongue."
       },
       {
         "type": "ai-graphic",

--- a/locales/en/embeds.json
+++ b/locales/en/embeds.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
     "id": "cm8q3vr0e0000l803tfleu4t4",
-    "name": "graphics-kit-embeds",
+    "name": "Graphic: Embeds",
     "storyboard": {
       "id": "cltmvxt5q0000l908irus4rdd",
       "name": "🔒 TEMPLATES"
     },
-    "lastSynced": "2025-03-26T17:16:03.468Z"
+    "lastSynced": "2026-07-10T20:27:43.098Z"
   },
   "story": {
     "embeds": []

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@reuters-graphics/graphics-components": "4.1.0",
+    "@reuters-graphics/graphics-components": "4.2.0",
     "language-tags": "^1.0.9",
     "slugify": "^1.6.9"
   },

--- a/pages/+page.svelte
+++ b/pages/+page.svelte
@@ -38,9 +38,17 @@
   shareDescription={content.shareDescription}
   shareImgPath={asset(`/${content.shareImgPath}`)}
   shareImgAlt={content.shareImgAlt}
+  shareImgWidth={1200}
+  shareImgHeight={628}
   publishTime={pkg?.reuters?.graphic?.published}
   updateTime={pkg?.reuters?.graphic?.updated}
   authors={pkg?.reuters?.graphic?.authors}
+  articleSection={content.section}
+  keywords={content.keywords
+    ?.split(',')
+    .map((k) => k.trim())
+    .filter(Boolean)}
+  locale={content.locale}
 />
 
 <Theme base="light">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@reuters-graphics/graphics-components':
-        specifier: 4.1.0
-        version: 4.1.0(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)))(@types/node@26.1.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(prettier@3.9.5)(react@19.2.7))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
+        specifier: 4.2.0
+        version: 4.2.0(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)))(@types/node@26.1.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(prettier@3.9.5)(react@19.2.7))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
       language-tags:
         specifier: ^1.0.9
         version: 1.0.9
@@ -20,7 +20,7 @@ importers:
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.206
-        version: 0.3.206(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.206(@anthropic-ai/sdk@0.109.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)
       '@astrojs/starlight':
         specifier: ^0.32.6
         version: 0.32.6(astro@5.18.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(sass@1.101.0)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0))
@@ -1902,8 +1902,8 @@ packages:
     resolution: {integrity: sha512-B7gEP3/ENe8t7Jl/ZuwPiuGx+jc0FczKQ/GBEgBRO+A90JxM6Suvv3ZqXToJkllhBRMHXyQcqLDy7jRgDHFaSA==}
     hasBin: true
 
-  '@reuters-graphics/graphics-components@4.1.0':
-    resolution: {integrity: sha512-9OytjVMI+revNQkhWxj9skm5UyM0TdoTY+bl0DN/w8DKwTNbe2VeGo3jL6myWrRlc/NOGj0d3rCw8BeYhJZ/iw==}
+  '@reuters-graphics/graphics-components@4.2.0':
+    resolution: {integrity: sha512-Cg4VN7+lsITYmyPopgPzeO+AshmHg9iXu7Q74l2zvk24s3y/95teSpDup5/H8mVdfIq2fF3kD+LLL3cOzRAjfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       svelte: ^5.0.0
@@ -7168,11 +7168,11 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.206(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.206(@anthropic-ai/sdk@0.109.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@anthropic-ai/sdk': 0.109.0(zod@4.4.3)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      zod: 4.4.3
+      '@anthropic-ai/sdk': 0.109.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      zod: 3.25.76
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.206
       '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.206
@@ -7183,12 +7183,12 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.206
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.206
 
-  '@anthropic-ai/sdk@0.109.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.109.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
     optionalDependencies:
-      zod: 4.4.3
+      zod: 3.25.76
 
   '@astrojs/compiler@2.13.1': {}
 
@@ -8353,7 +8353,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.28)
       ajv: 8.20.0
@@ -8370,8 +8370,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -8862,7 +8862,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@reuters-graphics/graphics-components@4.1.0(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)))(@types/node@26.1.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(prettier@3.9.5)(react@19.2.7))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@reuters-graphics/graphics-components@4.2.0(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0)))(@types/node@26.1.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(prettier@3.9.5)(react@19.2.7))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@fortawesome/free-regular-svg-icons': 6.7.2
       '@fortawesome/free-solid-svg-icons': 6.7.2
@@ -15140,10 +15140,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:

--- a/rngs-io.json
+++ b/rngs-io.json
@@ -5,7 +5,7 @@
       "rngsIo": "https://www.rngs.io/storyboards/cltmvxt5q0000l908irus4rdd/",
       "stories": {
         "cltmvzj5m0000lc089jz22aet": {
-          "name": "graphics-kit-page",
+          "name": "Graphic: Page",
           "rngsIo": "https://www.rngs.io/storyboards/cltmvxt5q0000l908irus4rdd/story/cltmvzj5m0000lc089jz22aet/",
           "syncPath": "locales/en/content.json",
           "preview": {
@@ -15,7 +15,7 @@
           }
         },
         "cm8q3vr0e0000l803tfleu4t4": {
-          "name": "graphics-kit-embeds",
+          "name": "Graphic: Embeds",
           "rngsIo": "https://www.rngs.io/storyboards/cltmvxt5q0000l908irus4rdd/story/cm8q3vr0e0000l803tfleu4t4/",
           "syncPath": "locales/en/embeds.json"
         }


### PR DESCRIPTION
## What

Fills in the `SEO` component's new metadata props (from graphics-components 4.2.0) across the page templates and the blog mod:

- `articleSection` ← content `section`
- `keywords` ← comma-separated content field, split into `string[]`
- `locale` ← content `locale` (e.g. `en_GB`)
- `shareImgWidth` / `shareImgHeight` (1200 × 628)

Applied to the base template pages ([pages/+page.svelte](pages/+page.svelte)) and the blog mod templates (main + `[date]/[slug]` post pages). Adds the backing `keywords`/`locale`/`section` fields to the content JSON.

## Typings

The blog mod's types are extended for the new fields, in **both** places:
- shipped [src/lib/post.ts](bin/mods/mods/make-blog/templates/src/lib/post.ts) — `keywords?` on `PostStory`; `keywords?`/`locale?` on `MainPageShell` (so scaffolded projects type-check)
- in-repo [_mocks.d.ts](bin/mods/mods/make-blog/templates/_mocks.d.ts) — same fields (so the templates type-check in this repo)

## Dependencies

Bumps `@reuters-graphics/graphics-components` to **4.2.0**.

## Testing

- `pnpm check` → 0 errors
- `test/build.test.ts` → 15 passed (metadata assertions hold with new content + SEO 4.2.0)
- `make-blog` mod test → 4 passed (builds a converted blog with the real `post.ts` types)
- Prettier clean

Includes a `minor` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)