### PR TITLE
Add wire-blocks skill

### DIFF
--- a/.changeset/petite-knives-study.md
+++ b/.changeset/petite-knives-study.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': minor
+---
+
+Adds the wire-blocks skill for wiring rngs.io content blocks into App.svelte, the isExternalUrl prop validator, and matching context doc updates.

--- a/.claude/context/assets.md
+++ b/.claude/context/assets.md
@@ -23,11 +23,40 @@ Never use relative paths to reference files in `src/statics/`. Always resolve th
 <img src={asset('/images/my-image.jpg')} alt="" />
 ```
 
-This applies to asset paths in content blocks too — always resolve `block.src` or similar fields with `asset`:
+This applies to asset paths in content blocks too — resolve `block.src` or similar fields with `asset`:
 
 ```svelte
 <FeaturePhoto src={asset(`/${block.src}`)} />
 ```
+
+### Local assets vs. external URLs
+
+Not every `src`-like field points at a file in `src/statics/`. A `photo` or `video` block may instead carry a full URL to an externally hosted file (a CDN, a partner's server, etc.). `asset()` must never wrap an external URL — doing so mangles it into a broken local path.
+
+Before wiring a field, check the actual value in `content.json`: a local path is relative (`images/photo.jpg`); an external URL is absolute or protocol-relative (`https://cdn.example.com/photo.jpg`, `//cdn.example.com/photo.jpg`).
+
+A single block _type_ can carry either kind of value across different content instances — the CMS field doesn't restrict authors to one or the other. Don't assume a block type is "always local" or "always external" from one example; check every instance of that type in the doc.
+
+Wire only for what you actually observe:
+
+- Every instance local → one branch, wrapped in `asset()`.
+- Every instance external → one branch, passed through unresolved.
+- Both kinds observed among that type's instances → two branches, using `isExternalUrl()` from `$utils/propValidators` to tell them apart at runtime:
+
+```svelte
+<script>
+  import { asset } from '$app/paths';
+  import { isExternalUrl } from '$utils/propValidators';
+</script>
+
+{#if isExternalUrl(block.src)}
+  <FeaturePhoto src={block.src} />
+{:else}
+  <FeaturePhoto src={asset(`/${block.src}`)} />
+{/if}
+```
+
+Don't add the `isExternalUrl()` dual-branch defensively for a case that isn't present in the doc — a photo block with only local instances gets only the `asset()` branch, not a speculative external one "in case an editor pastes a URL later." If the content shape changes in rngs.io, re-run the wiring then.
 
 ### In component SCSS
 

--- a/.claude/context/content.md
+++ b/.claude/context/content.md
@@ -77,14 +77,16 @@ To add a new component to the loop:
 1. Import the component in the script portion of the Svelte component, if it isn't imported already.
 2. Add a new `else if` condition in the `{#each content.blocks as block}` loop to handle the new block type.
 3. Pass the required props to the component, ensuring they match the structure of the content block object.
+4. If the block has a `src`-like field, check its actual value(s) in `content.json` first — it may be a local asset path or an external URL. Only write the branch(es) that match what you actually observe: a single `asset()`-wrapped branch if every instance of that block type is a local path, a single passthrough branch if every instance is an external URL, or both branches (using `isExternalUrl()`) only when you observe both kinds among that type's instances. See [`.claude/context/assets.md`](./assets.md#local-assets-vs-external-urls) for the branching pattern — don't add the dual-branch/`isExternalUrl()` treatment speculatively for a case not present in the doc.
 
-For example, to add a new FeaturePhoto:
+For example, given a doc where `feature-photo` blocks appear with both local and external `src` values:
 
 ```svelte
 <script lang="ts">
   // ...
 
   import { asset } from '$app/paths';
+  import { isExternalUrl } from '$utils/propValidators';
 
   import {
     Article,
@@ -108,6 +110,13 @@ For example, to add a new FeaturePhoto:
     <!-- Other block types -->
 
     <!-- Add new FeaturePhoto block -->
+  {:else if block.type === 'feature-photo' && isExternalUrl(block.src)}
+    <FeaturePhoto
+      src={block.src}
+      alt={block.alt}
+      caption={block.caption}
+      credit={block.credit}
+    />
   {:else if block.type === 'feature-photo'}
     <FeaturePhoto
       src={asset(`/${block.src}`)}

--- a/.claude/context/styling.md
+++ b/.claude/context/styling.md
@@ -49,3 +49,10 @@ Prefer fluid spacing tokens (prefixed with `f`, e.g. `fmb-3`, `fpy-2`) over fixe
 **Global styles** go in `src/lib/styles/global.scss`, already imported across all pages and embeds. Add additional global stylesheets as separate `.scss` files and import them in the specific page that needs them.
 
 Use `:global()` in component styles when targeting elements created by `{@html}` or third-party JS, since Svelte won't scope rules for elements it can't detect statically.
+
+## Writing CSS/SCSS for a request
+
+- **Scope tightly.** Target only the elements the request names — a specific class, component, or selector — never a bare tag selector (`div`, `p`, `a`) in global styles or a shared component, since that silently restyles every future use of that tag. Component styles are scoped by Svelte, so a bare tag selector there is fine.
+- **Check Baseline.** Before using a CSS feature, confirm it's [Baseline "Widely available"](https://web-platform-dx.github.io/web-features/) (or at minimum "Newly available") on [caniuse.com](https://caniuse.com) or [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS). If a feature is limited-availability, say so and suggest a fallback rather than using it silently.
+- **Be concise.** Reuse existing tokens/mixins (see above) over new raw CSS. Write the fewest rules and selectors that satisfy the request — no defensive overrides for cases the request didn't mention.
+- **Ask when the target is unclear.** If the request doesn't make clear which element(s) it should affect (e.g. "make the text bigger" in a component with several text elements), ask which one before writing a selector broad enough to guess.

--- a/.claude/skills/wire-blocks/SKILL.md
+++ b/.claude/skills/wire-blocks/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: wire-blocks
+description: Use when asked to wire rngs.io content blocks into App.svelte, or convert/update it from content.json.
+allowed-tools: Read Edit Write Grep Glob Bash AskUserQuestion
+---
+
+## Instructions
+
+Read `.claude/context/content.md` first — it defines the content block shape and the pairing convention this skill implements. Also read `.claude/context/assets.md#local-assets-vs-external-urls` — it distinguishes local asset paths from external URLs, which step 5 wires differently.
+
+Every prop value wired into `App.svelte` comes from `locales/en/content.json` (or the file named in step 2). When a field's prop mapping or a block's matching component is unclear, skip that field or block (fallback/skip per steps 5–6) or ask the user.
+
+`locales/en/content.json` is synced from rngs.io — treat it as read-only. When new content fields are needed, tell the user what ArchieML to add in rngs.io instead (see `.claude/llms/archieml/docs.md`).
+
+Keep `block` loosely typed and access fields directly as `block.<field>` — no per-block-type interfaces, and leave `block` itself uncast. Because `content.json`'s inferred type is loose CMS data, some lines will carry TS/ESLint diagnostics (e.g. `string | undefined` into a required prop); leave those in place. An inline `as` cast on a single _derived_ value is fine — e.g. narrowing a shared helper's return type to a component's narrower prop type. That narrows one value; it isn't shaping the block.
+
+1. Run `pnpm stories:sync` to ensure `locales/en/content.json` is up to date with the latest content from rngs.io. If `pnpm stories:sync` fails or the command is not found, warn the user and exit without making any changes.
+2. Read `locales/en/content.json`. The blocks to wire live at `story.blocks` (or top-level `blocks` if there's no `story` wrapper). Note every distinct `type` present. For each `src`-like field (`src`, `poster`, etc.), look at its actual value(s) to tell a local path from an external URL — the field name alone doesn't. If `locales/en/content.json` is not present, ask the user which file to use instead.
+3. Before writing any code, check that the blocks array isn't malformed: it must be an array, and every entry must be an object with a `type` string. If it isn't — e.g. a block is missing `type`, a block came through as a string/null instead of an object, or entries bled into each other — this is almost always the rngs.io doc, not this skill: a missing `:end` closing a multi-line field, or a missing `[]` closing the `[blocks]` array. Warn the user with `AskUserQuestion`, naming the specific block (index and what's wrong with it) and the likely ArchieML fix, and ask whether to proceed anyway. Only continue if they confirm.
+
+   Also check for a `type` key sitting directly on `story` itself (outside `blocks`) — `story` never has its own `type` field, so this means a whole block leaked out of the `[blocks]` array, usually because `[]` closed the array before that block's `type:` line was written. Warn the user with `AskUserQuestion`, naming the leaked fields and the likely ArchieML fix (move the fields back inside `[blocks]`, closing `[]` after the new block instead of before it).
+
+4. Read the current `src/lib/App.svelte` to see which block types are already handled in the `{#each content.blocks as block}` loop and which components are already imported.
+5. For each block type with no matching `{:else if}` branch:
+   - Find the matching component in `@reuters-graphics/graphics-components` — check `.claude/llms/graphics-components/components/index.md` for the component list, then its individual doc for props. The docs aren't exhaustive (a component can share a source file/export group with another and be missing from `index.md`), so when a block type's shape could match more than one export, grep `node_modules/@reuters-graphics/graphics-components/dist/index.d.ts` for related exports before settling on the one from the docs.
+   - When more than one component could plausibly render a block type (e.g. a block-level wrapper vs. a single-item version), ask the user with `AskUserQuestion`, describing what each option renders, and use their answer.
+   - When no matching component exists, skip the block type, let the `{:else}` fallback handle it, and report it to the user as unhandled.
+   - Add the component to the import statement.
+   - Add an `{:else if block.type === '<type>'}` branch passing the block's properties as props, matching prop names/types from the component's docs. A content field maps to a prop when the name matches exactly or is an unambiguous variant (abbreviation, casing, missing word — e.g. `handleClr` → `handleColour`, `img` → `image`). When it's genuinely unclear which prop a field is for, leave that field out and tell the user.
+   - When a content field is a plain string but the matching prop's type is `Snippet`, wrap it in the simplest tag that fits the prop's purpose (e.g. `{#snippet caption()}<p>{block.caption}</p>{/snippet}`) — one wrapper tag, no extra markup, classes, or styling.
+   - For any `src`-like prop, check every instance of that block type in `content.json`, not just the first, then wire by what you observe:
+     - All local paths → one branch wrapping the value in `asset()` from `$app/paths`. Check each local path exists under `src/statics/` — wire it regardless, but note any missing file for the step 7 report.
+     - All external URLs → one branch passing the value through unresolved (external URLs stay unwrapped).
+     - Both kinds present → add `{:else if block.type === '<type>' && isExternalUrl(block.src)}` (pass through) _before_ the `asset()` branch. Add the `isExternalUrl()` branch only when you actually observe both kinds — a later sync triggers the split, not this run.
+6. Leave the final `{:else}` fallback (e.g. `LogBlock` for unknown types) in place.
+7. After editing, report which block types were newly wired and which components they map to. Include a warning for any local asset path noted missing in step 5, naming the block type and path, so the user knows rendering may break until the file is added.
+8. When the task is a full convert/update of `App.svelte` (not a targeted request to wire specific blocks), also check the reverse case: for each `{:else if block.type === '<type>'}` branch already in `App.svelte`, confirm `<type>` still appears among the block types noted in step 2. When a branch's type no longer appears in `content.json`, list those orphaned types for the user with `AskUserQuestion` (multi-select, one per orphaned type) asking which to remove. For each the user selects, delete that `{:else if}` branch and drop its component import if no other branch still uses it.

--- a/.claude/skills/wire-blocks/evals/wire-blocks.eval.ts
+++ b/.claude/skills/wire-blocks/evals/wire-blocks.eval.ts
@@ -1,0 +1,94 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  type SDKMessage,
+  type SDKResultSuccess,
+} from '@anthropic-ai/claude-agent-sdk';
+import {
+  createWorktree,
+  removeWorktree,
+  type Worktree,
+} from '../../_utils/worktree';
+import { runSkill } from '../../_utils/runner';
+
+describe('wire-blocks', () => {
+  let worktree: Worktree;
+  let messages: SDKMessage[];
+
+  beforeAll(async () => {
+    worktree = createWorktree();
+
+    // Stub out `stories:sync` — the skill's first step runs it against the
+    // live rngs.io CMS, which would overwrite the fixture below with
+    // whatever the real doc currently contains, making this eval flaky and
+    // network-dependent instead of testing against a known fixture.
+    const pkgPath = join(worktree.path, 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    pkg.scripts['stories:sync'] = 'node -e "process.exit(0)"';
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+    const contentPath = join(worktree.path, 'locales/en/content.json');
+    const content = JSON.parse(readFileSync(contentPath, 'utf8'));
+    content.story = content.story || {};
+    content.story.blocks = [
+      ...(content.story.blocks || []),
+      {
+        type: 'feature-photo',
+        src: 'images/test-photo.jpg',
+        alt: 'A test photo',
+        caption: 'A caption',
+        credit: 'Jane Doe',
+      },
+    ];
+    writeFileSync(contentPath, JSON.stringify(content, null, 2));
+
+    messages = await runSkill(
+      'wire-blocks',
+      'Wire the new feature-photo content block into src/lib/App.svelte.',
+      worktree.path
+    );
+  });
+
+  afterAll(() => {
+    removeWorktree(worktree);
+  });
+
+  it('was invoked via the skill system', () => {
+    const result = messages.find(
+      (m): m is SDKResultSuccess => m.type === 'result' && !('error' in m)
+    );
+    expect(result?.is_error).toBe(false);
+    expect(result?.num_turns).toBeGreaterThan(0);
+    expect(result?.stop_reason).toBe('end_turn');
+  });
+
+  it('adds a branch and import for the new block type', () => {
+    const appSvelte = readFileSync(
+      join(worktree.path, 'src/lib/App.svelte'),
+      'utf8'
+    );
+    expect(appSvelte).toContain('feature-photo');
+    expect(appSvelte).toContain('FeaturePhoto');
+  });
+
+  it('does not add a speculative external-URL branch when every instance is a local path', () => {
+    const appSvelte = readFileSync(
+      join(worktree.path, 'src/lib/App.svelte'),
+      'utf8'
+    );
+    const branchMatch = appSvelte.match(
+      /\{:else if block\.type === 'feature-photo'\}[\s\S]*?(?=\{:else)/
+    );
+    expect(branchMatch).not.toBeNull();
+    expect(branchMatch![0]).not.toContain('isExternalUrl');
+  });
+
+  it('does not modify locales/en/content.json', () => {
+    const content = readFileSync(
+      join(worktree.path, 'locales/en/content.json'),
+      'utf8'
+    );
+    expect(content).toContain('feature-photo');
+  });
+});

--- a/src/utils/propValidators/index.ts
+++ b/src/utils/propValidators/index.ts
@@ -38,6 +38,21 @@ export const inlineAdNumber = (n: string) => {
 };
 
 /**
+ * Whether a src-like value is an external URL rather than a local project asset path.
+ *
+ * @example
+ * ```
+ * isExternalUrl('https://example.com/video.mp4'); // true
+ * isExternalUrl('//example.com/video.mp4'); // true
+ * isExternalUrl('images/photo.jpg'); // false
+ * ```
+ * @param src Source path or URL
+ * @returns `true` if `src` is an absolute or protocol-relative URL
+ */
+export const isExternalUrl = (src: string) =>
+  /^(https?:)?\/\//i.test(src.trim());
+
+/**
  * Coerce a truth-y value to a proper boolean.
  *
  * @example


### PR DESCRIPTION
## Summary
- Adds the `wire-blocks` skill, which wires rngs.io content blocks from `locales/en/content.json` into `src/lib/App.svelte`'s block loop, matching each block type to a `@reuters-graphics/graphics-components` component and its props.
- Adds `isExternalUrl` to `src/utils/propValidators` so `src`-like fields can be branched between local asset paths (wrapped in `asset()`) and external URLs (passed through unresolved) — the skill and context docs both reference this helper.
- Updates `.claude/context/assets.md` and `.claude/context/content.md` with the local-vs-external-URL wiring pattern.
- Adds a "Writing CSS/SCSS for a request" section to `.claude/context/styling.md` (scoping, Baseline checks, conciseness, asking when the target element is unclear).
- Adds an eval (`wire-blocks.eval.ts`) that runs the skill against a worktree fixture and checks it wires a new block type without a speculative external-URL branch.

## How to test this skill
1. From this branch, run `bluprint preview` to scaffold this branch into a temp project.
2. In the scaffolded project, run `pnpm stories:connect` and connect it to the [RNGS.io story `cmlj8onsa0001if04vn8o9lip`](https://www.rngs.io/stories/cmlj8onsa0001if04vn8o9lip/) as `locales/en/content.json`.
3. Ask Claude to wire the new content blocks into `App.svelte` (invokes the `wire-blocks` skill, which syncs the story itself) and check the result.

## Test plan
- [ ] `pnpm test` (runs `.claude/skills/**/*.eval.ts` via vitest, including the new eval — requires a live model call)
- [ ] `pnpm check`