### PR TITLE
Gracefully handle embed share image publication fallbacks

### DIFF
--- a/.changeset/graceful-share-image-fallback.md
+++ b/.changeset/graceful-share-image-fallback.md
@@ -1,0 +1,5 @@
+---
+"@reuters-graphics/graphics-kit": minor
+---
+
+Add build-time embed share-image validation with graceful publisher preview fallbacks and a strict preflight command.

--- a/bin/share-images/index.ts
+++ b/bin/share-images/index.ts
@@ -1,0 +1,352 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import * as cheerio from 'cheerio';
+import sharp from 'sharp';
+import type { Plugin } from 'vite';
+
+const VALID_IMAGE_FORMATS = new Set(['.jpg', '.jpeg', '.png', '.gif']);
+
+export const DEFAULT_SHARE_IMAGE_PLACEHOLDER =
+  'src/statics/images/reuters-graphics.jpg';
+
+export type ShareImageSource = 'metadata' | 'fallback';
+
+export interface ShareImageResult {
+  embedId: string;
+  htmlPath: string;
+  previewPath: string;
+  source: ShareImageSource;
+  sourcePath?: string;
+  fallback: boolean;
+  reason?: string;
+  metadataUpdated: boolean;
+  remediation?: string;
+}
+
+export interface ShareImageCheckOptions {
+  root?: string;
+  dist?: string;
+  placeholder?: string;
+  strict?: boolean;
+  log?: Pick<Console, 'log' | 'warn' | 'error'>;
+}
+
+const toPosix = (filePath: string) => filePath.split(path.sep).join('/');
+
+const exists = (filePath: string) => fs.existsSync(filePath);
+
+const isValidImageType = (filePath: string) =>
+  VALID_IMAGE_FORMATS.has(path.extname(filePath).toLowerCase());
+
+const validateReadableImage = async (filePath: string) => {
+  if (!exists(filePath)) return `File not found: ${filePath}`;
+  if (!isValidImageType(filePath)) {
+    return `Unsupported image type: ${path.basename(filePath)}`;
+  }
+  try {
+    await sharp(filePath).metadata();
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `Could not read image ${filePath}: ${message}`;
+  }
+};
+
+const getEmbedHtmlPaths = (distDir: string) => {
+  const embedsRoot = path.join(distDir, 'embeds');
+  if (!exists(embedsRoot)) return [];
+
+  const htmlPaths: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(entryPath);
+      else if (entry.name === 'index.html') htmlPaths.push(entryPath);
+    }
+  };
+
+  walk(embedsRoot);
+  return htmlPaths.sort();
+};
+
+const getMetadata = (html: string) => {
+  const $ = cheerio.load(html);
+  return {
+    $,
+    canonicalUrl:
+      $('link[rel="canonical"]').attr('href') ||
+      $('meta[property="og:url"]').attr('content') ||
+      '',
+    ogImageUrl: $('meta[property="og:image"]').attr('content') || '',
+  };
+};
+
+const resolveMetadataImagePath = (
+  htmlPath: string,
+  canonicalUrl: string,
+  imageUrl: string
+) => {
+  if (!imageUrl) return { error: 'No og:image metadata found.' };
+  if (!canonicalUrl) return { error: 'No canonical URL metadata found.' };
+
+  try {
+    const pagePath = new URL(canonicalUrl).pathname.replace(/index\.html$/, '');
+    const imagePath = new URL(imageUrl).pathname;
+    const relativeImagePath = path.posix.relative(pagePath, imagePath);
+    return {
+      imagePath: path.join(path.dirname(htmlPath), relativeImagePath),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { error: `Could not resolve og:image URL: ${message}` };
+  }
+};
+
+const writePngPreview = async (sourcePath: string, previewPath: string) => {
+  fs.mkdirSync(path.dirname(previewPath), { recursive: true });
+  await sharp(sourcePath).png().toFile(previewPath);
+};
+
+const getPlaceholderUrl = (
+  htmlPath: string,
+  canonicalUrl: string,
+  placeholderDistPath: string
+) => {
+  if (!canonicalUrl) return '';
+  const relativePlaceholderPath = toPosix(
+    path.relative(path.dirname(htmlPath), placeholderDistPath)
+  );
+  try {
+    return new URL(relativePlaceholderPath, canonicalUrl).href;
+  } catch {
+    return '';
+  }
+};
+
+const upsertMeta = (
+  $: cheerio.CheerioAPI,
+  selector: string,
+  attrs: Record<string, string>,
+  valueAttr: 'content' | 'href',
+  value: string
+) => {
+  const existing = $(selector).first();
+  if (existing.length) {
+    existing.attr(valueAttr, value);
+    return;
+  }
+  $('head').append('\n' + $('<meta>').attr({ ...attrs, [valueAttr]: value }));
+};
+
+const updateHtmlFallbackMetadata = (
+  htmlPath: string,
+  placeholderUrl: string,
+  reason: string
+) => {
+  if (!placeholderUrl) return false;
+  const html = fs.readFileSync(htmlPath, 'utf-8');
+  const { $ } = getMetadata(html);
+
+  upsertMeta(
+    $,
+    'meta[property="og:image"]',
+    { property: 'og:image' },
+    'content',
+    placeholderUrl
+  );
+  upsertMeta(
+    $,
+    'meta[name="twitter:image"]',
+    { name: 'twitter:image' },
+    'content',
+    placeholderUrl
+  );
+  if (!$('meta[name="twitter:image:alt"]').length) {
+    $('head').append(
+      '\n' +
+        $('<meta>').attr({
+          name: 'twitter:image:alt',
+          content: 'Reuters Graphics placeholder image.',
+        })
+    );
+  }
+  upsertMeta(
+    $,
+    'meta[name="reuters:share-image:fallback"]',
+    { name: 'reuters:share-image:fallback' },
+    'content',
+    reason
+  );
+
+  fs.writeFileSync(htmlPath, $.html());
+  return true;
+};
+
+const remediation = (placeholder: string) =>
+  `Create or restore the intended share image, make sure the page's og:image points to a readable JPG/PNG/GIF in src/statics, or replace the fallback placeholder (${placeholder}) before publishing.`;
+
+export const checkEmbedShareImages = async ({
+  root = process.cwd(),
+  dist = 'dist',
+  placeholder = DEFAULT_SHARE_IMAGE_PLACEHOLDER,
+  strict = false,
+  log = console,
+}: ShareImageCheckOptions = {}) => {
+  const distDir = path.resolve(root, dist);
+  const placeholderPath = path.resolve(root, placeholder);
+  const placeholderDistPath = path.join(
+    distDir,
+    'cdn',
+    path.relative(path.resolve(root, 'src/statics'), placeholderPath)
+  );
+  const manifestPath = path.join(distDir, 'share-images-manifest.json');
+  const htmlPaths = getEmbedHtmlPaths(distDir);
+
+  const placeholderProblem = await validateReadableImage(placeholderPath);
+  if (placeholderProblem) {
+    throw new Error(
+      `Share-image fallback placeholder is unavailable. ${placeholderProblem}`
+    );
+  }
+
+  const results: ShareImageResult[] = [];
+
+  for (const htmlPath of htmlPaths) {
+    const embedId = toPosix(path.relative(distDir, path.dirname(htmlPath)));
+    const previewPath = path.join(path.dirname(htmlPath), '_gfxpreview.png');
+    let sourcePath = '';
+    let source: ShareImageSource = 'metadata';
+    let fallbackReason = '';
+    let metadataUpdated = false;
+
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+    const { $, canonicalUrl, ogImageUrl } = getMetadata(html);
+    const existingFallback = $('meta[name="reuters:share-image:fallback"]')
+      .attr('content')
+      ?.trim();
+
+    if (existingFallback) fallbackReason = existingFallback;
+    else {
+      const resolved = resolveMetadataImagePath(
+        htmlPath,
+        canonicalUrl,
+        ogImageUrl
+      );
+      if (resolved.error) fallbackReason = resolved.error;
+      else if (resolved.imagePath) {
+        const problem = await validateReadableImage(resolved.imagePath);
+        if (problem) fallbackReason = problem;
+        else sourcePath = resolved.imagePath;
+      }
+    }
+
+    if (fallbackReason) {
+      source = 'fallback';
+      sourcePath = placeholderPath;
+      await writePngPreview(placeholderPath, previewPath);
+
+      const html = fs.readFileSync(htmlPath, 'utf-8');
+      const { canonicalUrl } = getMetadata(html);
+      const placeholderUrl = getPlaceholderUrl(
+        htmlPath,
+        canonicalUrl,
+        placeholderDistPath
+      );
+      metadataUpdated = updateHtmlFallbackMetadata(
+        htmlPath,
+        placeholderUrl,
+        fallbackReason
+      );
+
+      results.push({
+        embedId,
+        htmlPath,
+        previewPath,
+        source,
+        sourcePath,
+        fallback: true,
+        reason: fallbackReason,
+        metadataUpdated,
+        remediation: remediation(placeholder),
+      });
+      continue;
+    }
+
+    await writePngPreview(sourcePath, previewPath);
+    results.push({
+      embedId,
+      htmlPath,
+      previewPath,
+      source,
+      sourcePath,
+      fallback: false,
+      metadataUpdated: false,
+    });
+  }
+
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        placeholder,
+        embeds: results.map((result) => ({
+          ...result,
+          htmlPath: path.relative(root, result.htmlPath),
+          previewPath: path.relative(root, result.previewPath),
+          sourcePath:
+            result.sourcePath ?
+              path.relative(root, result.sourcePath)
+            : undefined,
+        })),
+      },
+      null,
+      2
+    )
+  );
+
+  const fallbacks = results.filter((result) => result.fallback);
+  for (const fallback of fallbacks) {
+    log.warn(
+      `Share image fallback for ${fallback.embedId}: ${fallback.reason}\n` +
+        `  Wrote ${path.relative(root, fallback.previewPath)} from ${placeholder}.\n` +
+        `  ${fallback.remediation}`
+    );
+  }
+
+  if (strict && fallbacks.length) {
+    throw new Error(
+      `Share image preflight failed for ${fallbacks.length} embed(s). See ${path.relative(
+        root,
+        manifestPath
+      )} for details.`
+    );
+  }
+
+  return {
+    manifestPath,
+    results,
+    fallbackCount: fallbacks.length,
+  };
+};
+
+export const shareImagePreviewPlugin = (): Plugin => ({
+  name: 'bluprint-share-image-preview',
+  apply: 'build',
+  closeBundle: async () => {
+    await checkEmbedShareImages({
+      strict: process.env.SHARE_IMAGES_STRICT === 'true',
+    });
+  },
+});
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  checkEmbedShareImages({
+    strict: process.argv.includes('--strict'),
+  }).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/bin/share-images/index.ts
+++ b/bin/share-images/index.ts
@@ -82,6 +82,14 @@ const getMetadata = (html: string) => {
   };
 };
 
+const decodeUrlPathname = (pathname: string) => {
+  try {
+    return decodeURI(pathname);
+  } catch {
+    return pathname;
+  }
+};
+
 const resolveMetadataImagePath = (
   htmlPath: string,
   canonicalUrl: string,
@@ -91,8 +99,11 @@ const resolveMetadataImagePath = (
   if (!canonicalUrl) return { error: 'No canonical URL metadata found.' };
 
   try {
-    const pagePath = new URL(canonicalUrl).pathname.replace(/index\.html$/, '');
-    const imagePath = new URL(imageUrl).pathname;
+    const pagePath = decodeUrlPathname(new URL(canonicalUrl).pathname).replace(
+      /index\.html$/,
+      ''
+    );
+    const imagePath = decodeUrlPathname(new URL(imageUrl).pathname);
     const relativeImagePath = path.posix.relative(pagePath, imagePath);
     return {
       imagePath: path.join(path.dirname(htmlPath), relativeImagePath),
@@ -202,6 +213,15 @@ export const checkEmbedShareImages = async ({
   );
   const manifestPath = path.join(distDir, 'share-images-manifest.json');
   const htmlPaths = getEmbedHtmlPaths(distDir);
+
+  if (strict && !htmlPaths.length) {
+    throw new Error(
+      `Share image preflight failed: no embed index.html files found in ${path.relative(
+        root,
+        path.join(distDir, 'embeds')
+      )}.`
+    );
+  }
 
   const placeholderProblem = await validateReadableImage(placeholderPath);
   if (placeholderProblem) {

--- a/docs/content/docs/Developers/11-adding-pages.mdx
+++ b/docs/content/docs/Developers/11-adding-pages.mdx
@@ -109,3 +109,16 @@ Embed pages **must** have a canonical link element and should have a [`robots` m
 
 <PymChild polling={500} />
 ```
+
+### Embed share images
+
+Each embed needs a share image for the private producer-selection panel and Reuters Connect manifest. The image is generated at build time from the embed's metadata and is written beside the built embed as `_gfxpreview.png`, which is the file the publisher prefers when packaging media archives. This producer-panel image does **not** appear in the live embed.
+
+Use a real, meaningful image whenever possible by setting the embed page's `shareImgPath` to a JPG, PNG or GIF in `src/statics/`, usually through the `SEO` component. If that image is missing or cannot be decoded, the build falls back to `src/statics/images/reuters-graphics.jpg` so a late non-critical media-archive image problem does not block publication. The fallback is observable:
+
+- the build prints a warning naming the embed path and missing/broken image;
+- `dist/share-images-manifest.json` records the source image, fallback reason and remediation text;
+- the built embed gets a `reuters:share-image:fallback` marker naming the failure;
+- the built embed metadata is pointed at the placeholder only for fallback cases, so live SEO/social metadata is not silently left with a broken image URL.
+
+Run `pnpm share-images:check` before upload/publish for strict preflight. It uses the same checks but exits non-zero when an embed falls back, giving you an early signal in development or CI. To fix a warning, restore or export the intended image, update the embed's `shareImgPath`, then rebuild.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "publish:preview": "npx graphics-publisher preview",
     "publish:publish": "npx graphics-publisher publish",
     "publish:git-commit": "npx graphics github:push",
+    "share-images:check": "tsx ./bin/share-images/index.ts --strict",
     "startup:check-creds": "npx graphics dotfile:check",
     "startup:create-repo": "npx graphics github:create-repo",
     "startup": "npm-run-all startup:*",

--- a/test/share-images.test.ts
+++ b/test/share-images.test.ts
@@ -106,6 +106,27 @@ describe('embed share image checks', () => {
     expect(result.results[0].reason).toContain('Could not read image');
   });
 
+  it('uses URL-encoded og:image paths that point to valid local files', async () => {
+    await writeImage(
+      path.join(root, 'dist/cdn/images/custom image.jpg'),
+      '#00ff00'
+    );
+    fs.writeFileSync(
+      path.join(root, 'dist/embeds/en/page/index.html'),
+      html(
+        'https://www.reuters.com/graphics/testing/cdn/images/custom%20image.jpg'
+      )
+    );
+
+    const result = await checkEmbedShareImages({ root, log });
+
+    expect(result.fallbackCount).toBe(0);
+    expect(result.results[0]).toMatchObject({
+      source: 'metadata',
+      fallback: false,
+    });
+  });
+
   it('updates embed metadata to the placeholder only for fallback cases', async () => {
     await checkEmbedShareImages({ root, log });
 
@@ -169,6 +190,14 @@ describe('embed share image checks', () => {
     await expect(
       checkEmbedShareImages({ root, log, strict: true })
     ).rejects.toThrow(/Share image preflight failed for 1 embed/);
+  });
+
+  it('fails strict preflight when no embed html files are found', async () => {
+    fs.rmSync(path.join(root, 'dist/embeds'), { recursive: true, force: true });
+
+    await expect(
+      checkEmbedShareImages({ root, log, strict: true })
+    ).rejects.toThrow(/no embed index\.html files found/);
   });
 
   it('preserves normal publishing output when no fallback is needed', async () => {

--- a/test/share-images.test.ts
+++ b/test/share-images.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import sharp from 'sharp';
+import * as cheerio from 'cheerio';
+import { checkEmbedShareImages } from '../bin/share-images';
+
+const writeImage = async (filePath: string, color: string) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  await sharp({
+    create: {
+      width: 1200,
+      height: 628,
+      channels: 4,
+      background: color,
+    },
+  })
+    .jpeg()
+    .toFile(filePath);
+};
+
+const html = (imageUrl: string) => `<!doctype html>
+<html>
+  <head>
+    <link rel="canonical" href="https://www.reuters.com/graphics/testing/embeds/en/page/" />
+    <meta property="og:url" content="https://www.reuters.com/graphics/testing/embeds/en/page/" />
+    <meta property="og:image" content="${imageUrl}" />
+    <meta name="twitter:image" content="${imageUrl}" />
+  </head>
+  <body>Embed</body>
+</html>`;
+
+describe('embed share image checks', () => {
+  let root: string;
+  let log: Pick<Console, 'log' | 'warn' | 'error'>;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'share-images-'));
+    log = {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await writeImage(
+      path.join(root, 'src/statics/images/reuters-graphics.jpg'),
+      '#f5f5f5'
+    );
+    fs.mkdirSync(path.join(root, 'dist/embeds/en/page'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'dist/embeds/en/page/index.html'),
+      html('https://www.reuters.com/graphics/testing/cdn/images/custom.jpg')
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('uses a valid custom og:image and writes a publisher preview image', async () => {
+    await writeImage(path.join(root, 'dist/cdn/images/custom.jpg'), '#ff0000');
+
+    const result = await checkEmbedShareImages({ root, log });
+
+    expect(result.fallbackCount).toBe(0);
+    expect(result.results[0]).toMatchObject({
+      embedId: 'embeds/en/page',
+      source: 'metadata',
+      fallback: false,
+    });
+    expect(
+      fs.existsSync(path.join(root, 'dist/embeds/en/page/_gfxpreview.png'))
+    ).toBe(true);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the placeholder when the metadata image is missing', async () => {
+    const result = await checkEmbedShareImages({ root, log });
+
+    expect(result.fallbackCount).toBe(1);
+    expect(result.results[0]).toMatchObject({
+      source: 'fallback',
+      fallback: true,
+      metadataUpdated: true,
+    });
+    expect(result.results[0].reason).toContain('File not found');
+    expect(
+      fs.existsSync(path.join(root, 'dist/embeds/en/page/_gfxpreview.png'))
+    ).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Share image fallback for embeds/en/page')
+    );
+  });
+
+  it('falls back when image compilation/decoding fails', async () => {
+    fs.mkdirSync(path.join(root, 'dist/cdn/images'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'dist/cdn/images/custom.jpg'),
+      'not an image'
+    );
+
+    const result = await checkEmbedShareImages({ root, log });
+
+    expect(result.fallbackCount).toBe(1);
+    expect(result.results[0].reason).toContain('Could not read image');
+  });
+
+  it('updates embed metadata to the placeholder only for fallback cases', async () => {
+    await checkEmbedShareImages({ root, log });
+
+    const $ = cheerio.load(
+      fs.readFileSync(
+        path.join(root, 'dist/embeds/en/page/index.html'),
+        'utf-8'
+      )
+    );
+    expect($('meta[property="og:image"]').attr('content')).toBe(
+      'https://www.reuters.com/graphics/testing/cdn/images/reuters-graphics.jpg'
+    );
+    expect($('meta[name="twitter:image"]').attr('content')).toBe(
+      'https://www.reuters.com/graphics/testing/cdn/images/reuters-graphics.jpg'
+    );
+    expect(
+      $('meta[name="reuters:share-image:fallback"]').attr('content')
+    ).toContain('File not found');
+  });
+
+  it('writes an observable manifest with fallback details', async () => {
+    const result = await checkEmbedShareImages({ root, log });
+    const manifest = JSON.parse(fs.readFileSync(result.manifestPath, 'utf-8'));
+
+    expect(manifest.placeholder).toBe(
+      'src/statics/images/reuters-graphics.jpg'
+    );
+    expect(manifest.embeds[0]).toMatchObject({
+      embedId: 'embeds/en/page',
+      source: 'fallback',
+      fallback: true,
+      htmlPath: 'dist/embeds/en/page/index.html',
+      previewPath: 'dist/embeds/en/page/_gfxpreview.png',
+    });
+    expect(manifest.embeds[0].remediation).toContain(
+      'Create or restore the intended share image'
+    );
+  });
+
+  it('can fail strict early preflight while non-strict builds remain graceful', async () => {
+    await expect(
+      checkEmbedShareImages({ root, log, strict: true })
+    ).rejects.toThrow(/Share image preflight failed for 1 embed/);
+
+    fs.rmSync(path.join(root, 'dist/embeds/en/page/_gfxpreview.png'), {
+      force: true,
+    });
+    fs.writeFileSync(
+      path.join(root, 'dist/embeds/en/page/index.html'),
+      html('https://www.reuters.com/graphics/testing/cdn/images/custom.jpg')
+    );
+
+    await expect(checkEmbedShareImages({ root, log })).resolves.toMatchObject({
+      fallbackCount: 1,
+    });
+  });
+
+  it('keeps strict preflight failing after a graceful fallback build', async () => {
+    await checkEmbedShareImages({ root, log });
+
+    await expect(
+      checkEmbedShareImages({ root, log, strict: true })
+    ).rejects.toThrow(/Share image preflight failed for 1 embed/);
+  });
+
+  it('preserves normal publishing output when no fallback is needed', async () => {
+    await writeImage(path.join(root, 'dist/cdn/images/custom.jpg'), '#ff0000');
+    await checkEmbedShareImages({ root, log });
+
+    const $ = cheerio.load(
+      fs.readFileSync(
+        path.join(root, 'dist/embeds/en/page/index.html'),
+        'utf-8'
+      )
+    );
+    expect($('meta[property="og:image"]').attr('content')).toBe(
+      'https://www.reuters.com/graphics/testing/cdn/images/custom.jpg'
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "tests/**/*.js",
     "tests/**/*.ts",
     "tests/**/*.svelte",
-    // Mods
+    // Build helpers and mods
+    "bin/share-images/**/*.ts",
     "bin/mods/**/*.svelte",
     "bin/mods/**/*.ts"
   ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { purgeStyles } from '@reuters-graphics/vite-plugin-purge-styles';
 import svelteKitPagesPlugin from './bin/svelte-kit/plugins/svelte-kit-pages/';
+import { shareImagePreviewPlugin } from './bin/share-images/';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { getBasePath } from '@reuters-graphics/graphics-kit-publisher';
 import { defineConfig } from 'vitest/config';
@@ -51,6 +52,7 @@ export default defineConfig({
   plugins: [
     sveltekit(),
     svelteKitPagesPlugin(),
+    shareImagePreviewPlugin(),
     purgeStyles({
       safeFiles: ['src/lib/styles/**/*.scss'],
     }),


### PR DESCRIPTION
## Summary

This PR adds a narrowly scoped share-image preflight/fallback step for built embed pages so non-critical producer-panel share image failures are caught early and do not block publication late in the workflow.

The current publisher behavior is strict: while packing media archives it calls `getPreviewImagePath()` for each embed, prefers a local `_gfxpreview.png`/`_gfxpreview.jpg`, then falls back to `og:image`. Missing `og:image`, missing canonical metadata, an unsupported extension, a missing image file, or a decode/Sharp conversion failure can throw while packaging the embed. The generated image is used for the Reuters Connect/producer-selection panel manifest (`statics/graphic.png` and `_gfxpreview.png`), not rendered inside the live embed itself.

## Design

Least-invasive hook: use existing scaffold build conventions instead of changing the publisher package.

- Add a Vite build plugin that scans `dist/embeds/**/index.html` after SvelteKit writes the static build.
- Resolve each embed's `og:image` relative to its canonical URL the same way the publisher does.
- Validate that image early with `sharp().metadata()` and generate `_gfxpreview.png` beside the built embed, matching the publisher's preferred preview-image convention.
- If metadata is missing, the image is absent, or Sharp cannot decode it, write `_gfxpreview.png` from the existing scaffold placeholder `src/statics/images/reuters-graphics.jpg` instead of leaving publication to fail late.
- For fallback cases, update only the built embed's `og:image`/`twitter:image` to the placeholder and add a `reuters:share-image:fallback` marker. This avoids publishing broken live metadata while keeping source pages/content untouched.
- Always write `dist/share-images-manifest.json` with source/fallback/remediation details.
- Add `pnpm share-images:check` as strict preflight: it uses the same scanner but exits non-zero when any embed required a fallback, giving CI/developers an early actionable signal.

## User-facing/dev-facing behavior

Before:

- A missing/broken embed share image can throw during publisher media-archive packing.
- The failure happens late and blocks publication even though the image is only for the private producer-selection/Connect manifest path.
- Remediation requires inferring the bad embed/image path from publisher errors.

After:

- Normal valid custom share images still produce publisher preview images and leave metadata unchanged.
- Missing or undecodable embed share images produce a warning with the embed ID, bad path/reason, and remediation guidance.
- Publication/build output remains packable by providing `_gfxpreview.png` from `src/statics/images/reuters-graphics.jpg`.
- Fallbacks are observable in `dist/share-images-manifest.json` and via the built embed's `reuters:share-image:fallback` marker.
- `pnpm share-images:check` can be run in CI/preflight to fail early until producers restore/export/fix the intended image.

## Safety / scope boundaries

- This does not mask missing primary graphic output, JS/CSS failures, invalid embed HTML, missing canonical metadata for normal successful cases, or source metadata problems in strict preflight.
- Source Svelte/content metadata is not rewritten.
- The fallback only applies to built embed share-image preview assets and built fallback metadata.
- The existing placeholder is treated as required; if it is missing or invalid, the build/check fails.
- The default scaffold still uses `src/statics/images/reuters-graphics.jpg` as a valid placeholder, so normal builds do not warn.

## Tests and validation

- `npx vitest run test/share-images.test.ts test/build.test.ts` — 23 tests passed.
- `npx vitest run` — full suite, 52 tests passed.
- `pnpm check` — 0 errors, 1 pre-existing Svelte warning in `bin/mods/mods/make-ai-embed/templates/pages/embeds/[locale]/[slug]/+page.svelte` about `data` reference.
- `TESTING=true npx vite build` — passed; wrote `dist/share-images-manifest.json` and `dist/embeds/en/page/_gfxpreview.png`.
- `pnpm share-images:check` — passed on the default valid scaffold image.
- `npx eslint bin/share-images/index.ts test/share-images.test.ts vite.config.ts` — passed.
- `npx prettier --check bin/share-images/index.ts test/share-images.test.ts vite.config.ts docs/content/docs/Developers/11-adding-pages.mdx package.json tsconfig.json .changeset/graceful-share-image-fallback.md` — passed.
- Attempted full `npx eslint .`; the process was SIGKILLed after several minutes with no lint output. Targeted lint on changed TS/Vite files passed, and the pre-commit hook's Prettier/file-size checks passed.

## Notes

This is intentionally separate from PR #321 and does not touch its branch.
