### PR TITLE
chore: add diagnose npm script

### DIFF
--- a/.changeset/add-diagnose-script.md
+++ b/.changeset/add-diagnose-script.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': patch
+---
+
+Add a `diagnose` npm script that runs `graphics-publisher diagnose`, placed just above `mods` so it surfaces there in the VSCode npm scripts view.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "pub": "npm-run-all publish:publish stories:autolink publish:git-commit",
     "build": "vite build",
     "build:preview": "PREVIEW=true vite build",
+    "diagnose": "npx graphics-publisher diagnose",
     "mods": "tsx ./bin/mods/index.ts mods",
     "savile": "savile row ./src/statics/images",
     "stories:unconfig": "tsx ./bin/mods/index.ts unconfig-rngs-io",


### PR DESCRIPTION
## Summary

Adds a `diagnose` npm script that runs `graphics-publisher diagnose`, following the same `npx graphics-publisher <command>` pattern as the existing `upload`/`preview`/`pub` scripts.

It's placed directly above `mods` in `package.json` so it surfaces just above the mod script in the VSCode npm scripts view, which lists scripts in file order.

```diff
     "build:preview": "PREVIEW=true vite build",
+    "diagnose": "npx graphics-publisher diagnose",
     "mods": "tsx ./bin/mods/index.ts mods",
```

Includes a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)