### PR TITLE
chore: disable pnpm minimumReleaseAge gate

### DIFF
--- a/.changeset/remove-release-age-gate.md
+++ b/.changeset/remove-release-age-gate.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': patch
+---
+
+Disable pnpm's `minimumReleaseAge` gate (`minimumReleaseAge: 0`) in `pnpm-workspace.yaml`. Projects are scaffolded from this template's committed lockfile via `pnpm install`, so under pnpm 11 (which enforces a 24h default) any lockfile entry published within that window would block a fresh scaffold entirely until the package aged out. Turning the gate off keeps scaffolding reliable regardless of when third-party dependency versions land. Also removes the now-redundant `minimumReleaseAgeExclude` for `@reuters-graphics/*`.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,8 +33,9 @@ allowBuilds:
   svelte-preprocess: true
 
 # pnpm 11 enforces a minimum release age (default 1440 min / 24h) before a
-# newly published version can be installed. Exempt our own scoped packages so
-# freshly released @reuters-graphics/* versions install immediately; all other
-# dependencies keep the default waiting period. (Ignored by pnpm 10.)
-minimumReleaseAgeExclude:
-  - '@reuters-graphics/*'
+# newly published version can be installed. We disable it (0 = no waiting
+# period): projects are scaffolded from this template's committed lockfile via
+# `pnpm install`, so a lockfile entry published within the window would block a
+# fresh scaffold entirely for pnpm 11 users until the package aged out. (Ignored
+# by pnpm 10, which never enforced the gate.)
+minimumReleaseAge: 0


### PR DESCRIPTION
## Summary

Disables pnpm's `minimumReleaseAge` gate in `pnpm-workspace.yaml` (`minimumReleaseAge: 0`) and removes the now-redundant `minimumReleaseAgeExclude` for `@reuters-graphics/*`.

## Why

pnpm 11 enforces a 24h `minimumReleaseAge` by default. New projects are scaffolded from **this template's committed `pnpm-lock.yaml`**, which ships in the bluprint tarball, and `bluprint.config.ts` runs `pnpm install` with `failOnError: true` during scaffolding.

That combination means: whenever the committed lockfile pins any non-`@reuters-graphics/*` package published **less than 24h ago**, a fresh scaffold on **pnpm 11 hard-fails** until the package ages out. This just happened — a merged third-party dependency bump pulled in five freshly published `@smithy/*` transitive deps (via the publisher), and `pnpm install` refused them with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`.

The `@reuters-graphics/*` exclude only ever protected our own packages; third-party/transitive bumps still opened the window. Since scaffolding reliability matters more here than a per-project release-age gate, we turn it off entirely for the template and everything scaffolded from it.

```diff
-minimumReleaseAgeExclude:
-  - '@reuters-graphics/*'
+minimumReleaseAge: 0
```

## Notes

- Only `pnpm-workspace.yaml` changes — `pnpm install` with the gate off does **not** alter `pnpm-lock.yaml`.
- Patch changeset included.
- pnpm 10 users were never affected (they ignore the setting); this makes pnpm 11 behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)