### PR TITLE
chore: update @reuters-graphics/savile to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@reuters-graphics/graphics-kit-publisher": "^3.4.7",
     "@reuters-graphics/illustrator-exports": "^0.0.2",
     "@reuters-graphics/rngs-io-client": "^0.1.12",
-    "@reuters-graphics/savile": "^0.1.1",
+    "@reuters-graphics/savile": "^0.2.0",
     "@reuters-graphics/vite-plugin-purge-styles": "^0.0.4",
     "@reuters-graphics/yaks-eslint": "^0.1.1",
     "@reuters-graphics/yaks-prettier": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^0.1.12
         version: 0.1.12(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@reuters-graphics/savile':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.2.0
+        version: 0.2.0
       '@reuters-graphics/vite-plugin-purge-styles':
         specifier: ^0.0.4
         version: 0.0.4(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -2158,9 +2158,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@reuters-graphics/savile@0.1.1':
-    resolution: {integrity: sha512-jFHkpLWEK+jRhjhIboeobrUz3IZ3pFMqNGQQoK/7ttYAeuqx0vNMtj8120WAt+uhL/e1yavk+ZRwAlAzVi30wg==}
-    engines: {node: '>=18.0.0'}
+  '@reuters-graphics/savile@0.2.0':
+    resolution: {integrity: sha512-fHGvfZ1vio6RjVmxHB/KfCiul+CFu8T3Ilers13zumFs5EeYopK/WRkAx7XnapwRoR5oCDGmog49uyJiwsd3Rw==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
 
   '@reuters-graphics/server-client@2.0.5':
@@ -9518,14 +9518,13 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@reuters-graphics/savile@0.1.1':
+  '@reuters-graphics/savile@0.2.0':
     dependencies:
-      '@clack/core': 0.4.2
-      '@clack/prompts': 0.9.1
+      '@clack/prompts': 1.7.0
+      '@reuters-graphics/clack': 1.0.0
       dedent: 1.7.2
       glob: 11.1.0
       image-size: 1.2.1
-      is-unicode-supported: 2.1.0
       micromatch: 4.0.8
       nanoid: 5.1.16
       p-limit: 6.2.0


### PR DESCRIPTION
## Summary
- Bumps `@reuters-graphics/savile` devDependency from `^0.1.1` to `^0.2.0`
- No changeset (per request — dependency bump only, no template behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)