### PR TITLE
fix: bump sharp to ^0.34.5 to fix broken Docs build

### DIFF
--- a/.changeset/fix-sharp-docs-build.md
+++ b/.changeset/fix-sharp-docs-build.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit': patch
+---
+
+Fix the Docs GitHub Actions workflow, which was failing on every run since the `savile` 0.2.0 update. The repo had drifted to three different resolved `sharp` versions; the root-level pin (`^0.33.5`) was older than what `astro` itself now requires (`^0.34.0`), and that stale copy was falling back to a broken legacy native-binary build. Bumping the root `sharp` dependency to `^0.34.5` collapses the duplicate installs and lets Astro's image optimization use a working prebuilt binary.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "rimraf": "^6.1.3",
     "sade": "^1.8.1",
     "sass": "^1.101.0",
-    "sharp": "^0.33.5",
+    "sharp": "^0.34.5",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.2",
     "svelte-preprocess": "^6.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^1.101.0
         version: 1.101.0
       sharp:
-        specifier: ^0.33.5
-        version: 0.33.5
+        specifier: ^0.34.5
+        version: 0.34.5
       svelte:
         specifier: ^5.56.4
         version: 5.56.4(@typescript-eslint/types@8.63.0)
@@ -8516,8 +8516,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -14698,7 +14697,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@1.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- The Docs workflow has failed on every run since the `savile` 0.2.0 update (2026-07-28).
- Root cause: the root-level `sharp` pin (`^0.33.5`) had drifted behind Astro's own requirement (`^0.34.0`), leaving three different resolved `sharp` versions in the tree. Astro's bundled image service resolves `sharp` from the project root's `node_modules`, and that stale copy was falling back to a broken legacy native-binary build, crashing with `TypeError: A boolean was expected` while optimizing `docs/assets/hero.png`.
- Bumping the root pin to `^0.34.5` collapses the duplicate installs onto a version with working prebuilt binaries.

## Test plan
- [x] `pnpm astro build` succeeds locally, including image optimization of `hero.png` (2473kB → 37kB webp)
- [ ] Confirm the `Docs` GitHub Actions workflow passes on this PR