### PR TITLE
chore: name the package and version in dependency-update changesets

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -29,39 +29,130 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # Updates the tracked internal dependencies, then reports exactly which
+      # ones moved and to what version. The triggering dispatch carries no
+      # payload — and a single dispatch can pick up releases of more than one
+      # package anyway — so package.json before vs. after is the only reliable
+      # source for that. Emits nothing when no version actually changed, so a
+      # duplicate or no-op dispatch doesn't raise an empty PR.
       - name: Update dependencies
+        id: update
         run: |
-          pnpm update @reuters-graphics/graphics-components --latest
-          pnpm update @reuters-graphics/graphics-kit-publisher --latest
+          cat > "$RUNNER_TEMP/update-deps.mjs" <<'NODE'
+          import { execSync } from 'node:child_process';
+          import fs from 'node:fs';
 
-      - name: Create changeset
-        run: |
-          cat << EOF > .changeset/update-dependencies-$(date +%s).md
-          ---
-          '@reuters-graphics/graphics-kit': patch
-          ---
+          /** Internal packages to track, with the repo that publishes each. */
+          const PACKAGES = [
+            {
+              name: '@reuters-graphics/graphics-components',
+              repo: 'reuters-graphics/graphics-components',
+            },
+            {
+              name: '@reuters-graphics/graphics-kit-publisher',
+              repo: 'reuters-graphics/graphics-kit-publisher',
+            },
+          ];
 
-          Updates @reuters-graphics dependencies to latest versions.
-          EOF
+          /** Declared range for a package, from whichever block holds it. */
+          const specOf = (name) => {
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+            return pkg.dependencies?.[name] ?? pkg.devDependencies?.[name] ?? null;
+          };
+
+          /** Drop any range prefix (`^`, `~`, …) to leave a bare version. */
+          const bare = (spec) => spec?.replace(/^[^\d]*/, '') ?? null;
+
+          const before = new Map(PACKAGES.map((p) => [p.name, specOf(p.name)]));
+
+          execSync(
+            `pnpm update ${PACKAGES.map((p) => p.name).join(' ')} --latest`,
+            { stdio: 'inherit' }
+          );
+
+          const updated = [];
+          for (const p of PACKAGES) {
+            const from = bare(before.get(p.name));
+            const to = bare(specOf(p.name));
+            if (from && to && from !== to) updated.push({ ...p, from, to });
+          }
+
+          const outputs = [];
+          /** Always heredoc-quoted, so multi-line values survive intact. */
+          const emit = (key, value) =>
+            outputs.push(`${key}<<__GHA_EOF__\n${value}\n__GHA_EOF__`);
+          const flush = () =>
+            fs.appendFileSync(
+              process.env.GITHUB_OUTPUT,
+              `${outputs.join('\n')}\n`
+            );
+
+          if (updated.length === 0) {
+            emit('changed', 'false');
+            flush();
+            console.log('No tracked dependency changed version — nothing to do.');
+            process.exit(0);
+          }
+
+          const short = (p) => p.name.replace('@reuters-graphics/', '');
+          const notes = (p) => `https://github.com/${p.repo}/releases/tag/v${p.to}`;
+          const diff = (p) => `https://github.com/${p.repo}/compare/v${p.from}...v${p.to}`;
+
+          // This summary becomes the kit's CHANGELOG entry, so it has to name
+          // each package and the versions it moved between.
+          const summary =
+            updated.length === 1 ?
+              `Update \`${updated[0].name}\` from ${updated[0].from} to [${updated[0].to}](${notes(updated[0])}).`
+            : [
+                'Update internal dependencies:',
+                '',
+                ...updated.map(
+                  (p) => `- \`${p.name}\` from ${p.from} to [${p.to}](${notes(p)})`
+                ),
+              ].join('\n');
+
+          fs.writeFileSync(
+            `.changeset/update-dependencies-${Date.now()}.md`,
+            `---\n'@reuters-graphics/graphics-kit': patch\n---\n\n${summary}\n`
+          );
+
+          emit('changed', 'true');
+          emit(
+            'title',
+            `chore: update ${updated.map((p) => `${short(p)} to ${p.to}`).join(', ')}`
+          );
+          emit(
+            'body',
+            [
+              '## Summary',
+              '',
+              'Automated update triggered by an upstream release.',
+              '',
+              '## Changes',
+              '',
+              ...updated.map(
+                (p) =>
+                  `- \`${p.name}\` \`${p.from}\` → \`${p.to}\` — [release notes](${notes(p)}) · [full diff](${diff(p)})`
+              ),
+              '',
+              '---',
+              '🤖 This PR was automatically created by the dependency update workflow.',
+            ].join('\n')
+          );
+          flush();
+          NODE
+          node "$RUNNER_TEMP/update-deps.mjs"
 
       - name: Create Pull Request
+        if: steps.update.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore: update dependencies'
+          commit-message: ${{ steps.update.outputs.title }}
           branch: update-dependencies
           delete-branch: true
-          title: 'chore: Update dependencies'
-          body: |
-            ## Summary
-            Automated update triggered by upstream release.
-
-            ## Changes
-            - Updates @reuters-graphics/graphics-components to the latest version
-            - Updates @reuters-graphics/graphics-kit-publisher to the latest version
-
-            ---
-            🤖 This PR was automatically created by the dependency update workflow.
+          title: ${{ steps.update.outputs.title }}
+          body: ${{ steps.update.outputs.body }}
           labels: |
             dependencies
             automated


### PR DESCRIPTION
## Problem

The changeset this workflow generates was always the same string — `Updates @reuters-graphics dependencies to latest versions.` — so the kit's `CHANGELOG.md` has accumulated a dozen identical, indistinguishable entries:

```
- d9aeb03: Updates @reuters-graphics dependencies to latest versions.
- 0b039ce: Updates @reuters-graphics dependencies to latest versions.
- 171b4ae: Updates @reuters-graphics dependencies to latest versions.
…
```

There's no way to tell from a release what actually moved.

## Where the version info comes from

Both upstream repos dispatch a **bare `event-type` with no `client_payload`**, so there is nothing in the triggering event to read. The versions are instead derived by reading `package.json` before and after the update.

That's the better source anyway: this workflow runs `pnpm update` on *both* tracked packages on every dispatch, so a payload describing only the trigger would under-report. The 2026-07-29 run moved `graphics-components 4.6.1 → 4.7.0` **and** `graphics-kit-publisher ^3.4.7 → ^3.5.0` — both collapsed into one vague line.

## Result

One package updated:

> Update `@reuters-graphics/graphics-components` from 4.7.0 to [5.0.0](https://github.com/reuters-graphics/graphics-components/releases/tag/v5.0.0).

Both updated:

> Update internal dependencies:
> - `@reuters-graphics/graphics-components` from 4.7.0 to [4.8.0](https://github.com/reuters-graphics/graphics-components/releases/tag/v4.8.0)
> - `@reuters-graphics/graphics-kit-publisher` from 3.5.0 to [3.6.0](https://github.com/reuters-graphics/graphics-kit-publisher/releases/tag/v3.6.0)

The same list drives the PR title and commit message, which now read `chore: update graphics-components to 4.8.0, graphics-kit-publisher to 3.6.0` — matching the convention already used in manual commits like `f6a59fc`. The PR body additionally gets a full-diff compare link per package.

## Also fixes: empty PRs on no-op dispatches

A duplicate or no-op dispatch previously still wrote a changeset, and that file alone was enough of a diff for `create-pull-request` to raise a PR containing no actual dependency change. The step now emits `changed=false` and the PR step is gated on it.

## Test plan

- [x] Extracted the embedded script from the parsed YAML and ran it against a scratch manifest with a stubbed `pnpm`, covering all three paths: **both bump**, **one bumps**, **neither bumps**
- [x] Caret and exact-pin specs both normalize correctly (`^3.5.0` → `3.5.0`; `4.7.0` → `4.7.0`), matching how the two packages are actually declared (one in `dependencies` pinned exact, one in `devDependencies` with a caret)
- [x] Both generated link formats return HTTP 200
- [x] Confirmed the upstream `notify-downstream` job is gated on `needs: release` + `published == 'true'` with a 30s wait, so the git tag exists before the dispatch arrives and the CHANGELOG links won't 404
- [x] `prettier --check` clean

No changeset here, matching this repo's convention for `.github`-only changes (12/12 prior such commits added none) — the workflow is stripped on scaffold at `bluprint.config.ts:40`, so it never reaches a generated project.

## Follow-ups, not done here

- **Bump type is still hardcoded `patch`.** A `4.x → 5.0.0` jump in `graphics-components` still records a patch on the kit. Left as-is rather than changing release semantics unasked; could be derived from the dependency's semver delta.
- **`bluprint_svelte5-sreps` receives the same dispatches** and likely has the same workflow — this is worth porting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)